### PR TITLE
Support for different types of drilldowns and drilldowns with filters

### DIFF
--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -120,7 +120,7 @@ const Provider = <ClientState extends Partial<CoreStore>, ClientActions extends 
 }
 
 // TODO: Вынести
-function defaultParseLocation(loc: Location<any>): Route {
+export function defaultParseLocation(loc: Location<any>): Route {
     let path: string = loc.pathname
     if (path.startsWith('/')) {
         path = path.substring(1)


### PR DESCRIPTION
**Url example for drilldown with filters:** 
`screen/screenName/view/viewName?filters={"someBcName":"name.contains=11%26status.equalsOneOf=[\\"New\\", \\"Fixed\\"]", "someBcName2": "someField.contains=value"}`
Url parameter "filters" is valid JSON object with bcNames and filters. 
Responsibility for escaping special characters ("%26", "\", etc.) in JSON on whoever writes JSON.