### PR TITLE
Full hierarchy support

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -248,6 +248,13 @@ export class ActionPayloadTypes {
         dataItem: AssociatedItem,
         assocValueKey: string
     } = z
+    changeAssociationFull: {
+        bcName: string,
+        depth: number,
+        widgetName: string,
+        dataItem: AssociatedItem,
+        assocValueKey: string
+    } = z
     changeChildrenAssociations: {
         bcName: string,
         assocValueKey: string,
@@ -259,12 +266,24 @@ export class ActionPayloadTypes {
         assocValueKey: string,
         selected: boolean
     } = z
+    changeDescendantsAssociationsFull: {
+        bcName: string,
+        parentId: string,
+        depth: number,
+        assocValueKey: string,
+        selected: boolean
+    } = z
     dropAllAssociations: {
         bcNames: string[]
     } = z
     dropAllAssociationsSameBc: {
         bcName: string,
         depthFrom: number
+    } = z
+    dropAllAssociationsFull: {
+        bcName: string,
+        depth: number,
+        dropDescendants?: boolean
     } = z
     handleRouter: {
         path: string,

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -13,10 +13,11 @@ export function routerRequest(path: string, params: object) {
 }
 
 export function fetchBcData(screenName: string, bcUrl: string, params: GetParamsMap = {}) {
+    const noLimit = params._limit === 0
     const queryStringObject = {
         ...params,
-        _page: ('_page' in params) ? params._page : 1,
-        _limit: ('_limit' in params) ? params._limit : 30
+        _page: !noLimit && (('_page' in params) ? params._page : 1),
+        _limit: !noLimit && (('_limit' in params) ? params._limit : 30)
     }
     const url = applyParams(buildUrl`data/${screenName}/` + bcUrl, queryStringObject)
     return axiosGet<BcDataResponse>(url)

--- a/src/components/FullHierarchyTable/FullHierarchyTable.less
+++ b/src/components/FullHierarchyTable/FullHierarchyTable.less
@@ -1,0 +1,16 @@
+.container tr:global(.ant-table-expanded-row) > td {
+    padding-left: 0;
+    padding-right: 0;
+}
+
+.container :global(.ant-table-tbody) > tr > td {
+    border-bottom: none;
+}
+
+.table {
+    table-layout: fixed;
+}
+
+.selectColumn {
+    text-align: center;
+}

--- a/src/components/FullHierarchyTable/FullHierarchyTable.tsx
+++ b/src/components/FullHierarchyTable/FullHierarchyTable.tsx
@@ -1,0 +1,247 @@
+import React, {FunctionComponent} from 'react'
+import styles from './FullHierarchyTable.less'
+import {WidgetListField, WidgetTableMeta} from '../../interfaces/widget'
+import {AssociatedItem} from '../../interfaces/operation'
+import {Store} from '../../interfaces/store'
+import {Dispatch} from 'redux'
+import {connect} from 'react-redux'
+import {Icon, Table} from 'antd'
+import {ColumnProps, TableRowSelection} from 'antd/lib/table'
+import {DataItem, MultivalueSingleValue, PendingDataItem} from '../../interfaces/data'
+import {FieldType} from '../../interfaces/view'
+import MultivalueHover from '../ui/Multivalue/MultivalueHover'
+import Field from '../Field/Field'
+import {useAssocRecords} from '../../hooks/useAssocRecords'
+import {$do} from '../../actions/actions'
+
+interface FullHierarchyTableOwnProps {
+    meta: WidgetTableMeta,
+    assocValueKey?: string,
+    depth?: number,
+    parentId?: string,
+    selectable?: boolean
+}
+
+interface FullHierarchyTableProps {
+    data: AssociatedItem[],
+    loading: boolean,
+    pendingChanges: Record<string, PendingDataItem>,
+}
+
+interface FullHierarchyTableDispatchProps {
+    onSelect: (bcName: string, depth: number, dataItem: AssociatedItem, widgetName: string, assocValueKey: string) => void,
+    onDeselectAll: (bcName: string, depthFrom: number) => void,
+    onSelectAll: (bcName: string, parentId: string, depth: number, assocValueKey: string, selected: boolean) => void,
+}
+
+type FullHierarchyTableAllProps = FullHierarchyTableOwnProps & FullHierarchyTableProps & FullHierarchyTableDispatchProps
+
+const emptyData: AssociatedItem[] = []
+const emptyMultivalue: MultivalueSingleValue[] = []
+
+const Exp: FunctionComponent = (props: any) => {
+    if (!props.onExpand || props.record.noChildren) {
+        return null
+    }
+    const type = props.expanded ? 'minus-square' : 'plus-square'
+    return <Icon
+        style={{ fontSize: '20px' }}
+        type={type}
+        onClick={e => props.onExpand(props.record, e)}
+    />
+}
+
+const FullHierarchyTable: React.FunctionComponent<FullHierarchyTableAllProps> = (props) => {
+    const bcName = props.meta.bcName
+    const fields = props.meta.fields
+    const depthLevel = props.depth || 1
+    const indentLevel = depthLevel - 1
+
+    const hierarchyGroupSelection = props.meta.options && props.meta.options.hierarchyGroupSelection
+    const hierarchyGroupDeselection = props.meta.options && props.meta.options.hierarchyGroupDeselection
+    const hierarchyRadioAll = props.meta.options && props.meta.options.hierarchyRadioAll
+    const hierarchyRootRadio = props.meta.options && props.meta.options.hierarchyRadio
+
+    const selectedRecords = useAssocRecords(props.data, props.pendingChanges)
+    const [userOpenedRecords, setUserOpenedRecords] = React.useState([])
+
+    const tableRecords = React.useMemo(
+        () => {
+            return props.data
+                .filter((dataItem) => {
+                    return dataItem.level === depthLevel && (dataItem.level === 1 || dataItem.parentId === props.parentId)
+                })
+                .map((filteredItem) => {
+                    return {
+                        ...filteredItem,
+                        noChildren: !props.data.find((dataItem) => dataItem.parentId === filteredItem.id)
+                    }
+                })
+        },
+        [props.data, props.parentId, depthLevel]
+    )
+
+    const [preopenedRecordsInitiated, setPreopenedRecordsInitiated] = React.useState(false)
+    if (!preopenedRecordsInitiated && props.data && props.data.length) {
+        setPreopenedRecordsInitiated(true)
+        setUserOpenedRecords(selectedRecords
+            .filter((selectedItem) => {
+                const recordData = tableRecords.find((item) => item.id === selectedItem.id)
+                return !recordData || !recordData.noChildren
+            })
+            .map((selectedItem) => selectedItem.id)
+        )
+    }
+
+    const handleExpand = (expanded: boolean, dataItem: DataItem) => {
+        if (expanded) {
+            setUserOpenedRecords((prevState) => {
+                return [...prevState, dataItem.id]
+            })
+        } else {
+            setUserOpenedRecords((prevState) => {
+                return prevState.filter((v) => v !== dataItem.id)
+            })
+        }
+    }
+
+    const rowSelection: TableRowSelection<DataItem> = React.useMemo(() => {
+        if (props.selectable) {
+            return {
+                type: 'checkbox',
+                selectedRowKeys: selectedRecords.map(item => item.id),
+                onSelect: (record: AssociatedItem, selected: boolean) => {
+                    const dataItem = {
+                        ...record,
+                        _associate: selected,
+                        _value: record[props.assocValueKey],
+                    }
+
+                    if (hierarchyRadioAll) {
+                        props.onDeselectAll(bcName, depthLevel)
+                    } else if (hierarchyRootRadio && depthLevel === 1 && selected) {
+                        const rootSelectedRecord = selectedRecords.find((item) => item.level === 1)
+                        if (rootSelectedRecord) {
+                            props.onSelect(
+                                bcName,
+                                depthLevel,
+                                { ...rootSelectedRecord, _associate: false },
+                                props.meta.name,
+                                props.assocValueKey
+                            )
+                        }
+                    }
+
+                    if (!selected && hierarchyGroupDeselection || selected && hierarchyGroupSelection) {
+                        props.onSelectAll(bcName, record.id, depthLevel + 1, props.assocValueKey, selected)
+                    }
+
+                    props.onSelect(bcName, depthLevel, dataItem, props.meta.name, props.assocValueKey)
+                }
+            }
+        }
+        return undefined
+    }, [bcName, props.onSelect, props.parentId, selectedRecords, props.assocValueKey, depthLevel, props.parentId])
+
+    // Nested hierarchy level is drown by another table
+    const nestedHierarchy = (record: DataItem, index: number, indent: number, expanded: boolean) => {
+        return <ConnectedFullHierarchyTable
+            meta={props.meta}
+            assocValueKey={props.assocValueKey}
+            depth={depthLevel + 1}
+            parentId={record.id}
+            selectable
+        />
+    }
+
+    // Hierarchy levels are indented by empty columns with calculated width
+    const indentColumn = {
+        title: '',
+        key: '_indentColumn',
+        dataIndex: null as string,
+        className: styles.selectColumn,
+        width: `${50 + indentLevel * 50}px`,
+        render: (text: string, dataItem: AssociatedItem): React.ReactNode => {
+            return null
+        }
+    }
+
+    const columns: Array<ColumnProps<DataItem>> = React.useMemo(() => {
+        return [
+            indentColumn,
+            ...fields
+                .filter((item: WidgetListField) => item.type !== FieldType.hidden)
+                .map((item: WidgetListField) => ({
+                    title: item.title,
+                    key: item.key,
+                    dataIndex: item.key,
+                    render: (text: string, dataItem: any) => {
+                        if (item.type === FieldType.multivalue) {
+                            return <MultivalueHover
+                                data={(dataItem[item.key] || emptyMultivalue) as MultivalueSingleValue[]}
+                                displayedValue={item.displayedKey && dataItem[item.displayedKey]}
+                            />
+                        }
+                        if (item.type === FieldType.multifield) {
+                            return <Field
+                                bcName={bcName}
+                                cursor={dataItem.id}
+                                widgetName={props.meta.name}
+                                widgetFieldMeta={item}
+                                readonly
+                            />
+                        }
+                        return text
+                    }
+                }))
+        ]
+    }, [indentLevel, fields, props.meta.name])
+
+    return <div className={styles.container}>
+        <Table
+            className={styles.table}
+            rowSelection={rowSelection}
+            rowKey="id"
+            columns={columns}
+            pagination={false}
+            showHeader={depthLevel === 1}
+            expandIcon={Exp as any}
+            defaultExpandedRowKeys={undefined}
+            expandedRowKeys={userOpenedRecords}
+            onExpand={handleExpand}
+            dataSource={tableRecords}
+            expandedRowRender={nestedHierarchy}
+            expandIconAsCell={false}
+            expandIconColumnIndex={1}
+            loading={props.loading}
+        />
+    </div>
+}
+
+function mapStateToProps(store: Store, ownProps: FullHierarchyTableOwnProps): FullHierarchyTableProps {
+    const bcName = ownProps.meta.bcName
+    const bc = store.screen.bo.bc[bcName]
+    const loading = bc && bc.loading
+    return {
+        loading: loading,
+        data: (loading) ? emptyData : store.data[bcName] as AssociatedItem[],
+        pendingChanges: store.view.pendingDataChanges[bcName]
+    }
+}
+
+function mapDispatchToProps(dispatch: Dispatch, ownProps: FullHierarchyTableOwnProps): FullHierarchyTableDispatchProps {
+    return {
+        onSelect: (bcName: string, depth: number, dataItem: AssociatedItem, widgetName: string, assocValueKey: string) => {
+            dispatch($do.changeAssociationFull({ bcName, depth, widgetName: widgetName, dataItem, assocValueKey }))
+        },
+        onDeselectAll: (bcName: string, depthFrom: number) => {
+            dispatch($do.dropAllAssociationsFull({ bcName, depth: depthFrom, dropDescendants: true }))
+        },
+        onSelectAll: (bcName: string, parentId: string, depth: number, assocValueKey: string, selected: boolean) => {
+            dispatch($do.changeDescendantsAssociationsFull({ bcName, parentId, depth, assocValueKey, selected }))
+        }
+    }
+}
+
+const ConnectedFullHierarchyTable = connect(mapStateToProps, mapDispatchToProps)(FullHierarchyTable)
+export default ConnectedFullHierarchyTable

--- a/src/components/HierarchyTable/HierarchyTable.tsx
+++ b/src/components/HierarchyTable/HierarchyTable.tsx
@@ -84,7 +84,7 @@ export const HierarchyTable: FunctionComponent<HierarchyTableProps> = (props) =>
 
     const isRadio = hierarchyLevel && hierarchyLevel.radio
         || (!hierarchyLevel && hierarchyRadio)
-    const [selectedRecords] = useAssocRecords(props.data, props.pendingChanges, isRadio)
+    const selectedRecords = useAssocRecords(props.data, props.pendingChanges, isRadio)
 
     const rowSelection: TableRowSelection<DataItem> = React.useMemo(() => {
         if (props.selectable) {

--- a/src/components/SameBcHierarchyTable/SameBcHierarchyTable.tsx
+++ b/src/components/SameBcHierarchyTable/SameBcHierarchyTable.tsx
@@ -65,7 +65,7 @@ export const SameBcHierarchyTable: FunctionComponent<SameBcHierarchyTableProps> 
     const indentLevel = depthLevel - 1
     const hasNested = props.data && props.data.length
 
-    const [selectedRecords] = useAssocRecords(props.data, props.pendingChanges, hierarchyRadioAll)
+    const selectedRecords = useAssocRecords(props.data, props.pendingChanges, hierarchyRadioAll)
 
     const rowSelection: TableRowSelection<DataItem> = React.useMemo(() => {
         if (props.selectable) {

--- a/src/components/ui/Popup/Popup.tsx
+++ b/src/components/ui/Popup/Popup.tsx
@@ -13,6 +13,7 @@ interface PopupProps {
     showed: boolean,
     title?: string,
     bcName: string,
+    disablePagination?: boolean,
 }
 
 const widths = {
@@ -31,9 +32,11 @@ export function Popup(props: PopupProps) {
             width={width}
             onCancel={props.onCancelHandler}
             footer={<div className={styles.footerContainer}>
-                    <div className={styles.pagination}>
-                        <Pagination bcName={props.bcName} mode={PaginationMode.page} />
-                    </div>
+                    {(!props.disablePagination) &&
+                        <div className={styles.pagination}>
+                            <Pagination bcName={props.bcName} mode={PaginationMode.page} />
+                        </div>
+                    }
                     <div className={styles.actions}>
                         <Button onClick={props.onOkHandler} className={styles.buttonYellow}>
                             Выбрать

--- a/src/components/widgets/AssocListPopup/AssocListPopup.tsx
+++ b/src/components/widgets/AssocListPopup/AssocListPopup.tsx
@@ -10,6 +10,7 @@ import HierarchyTable from '../../../components/HierarchyTable/HierarchyTable'
 import AssocTable from './AssocTable'
 import {Skeleton} from 'antd'
 import SameBcHierarchyTable from '../../SameBcHierarchyTable/SameBcHierarchyTable'
+import FullHierarchyTable from '../../FullHierarchyTable/FullHierarchyTable'
 
 export interface IAssocListRecord {
     id: string,
@@ -67,21 +68,30 @@ export const AssocListPopup: FunctionComponent<IAssocListProps & IAssocListActio
         onOkHandler={saveData}
         onCancelHandler={cancelData}
         bcName={props.widget.bcName}
+        disablePagination={props.widget.options && props.widget.options.hierarchyFull}
     >
         {(props.bcLoading)
             ? <Skeleton loading paragraph={{rows: 5}} />
-            : (props.widget.options && (props.widget.options.hierarchy || props.widget.options.hierarchySameBc))
-                ? (props.widget.options.hierarchySameBc)
-                    ? <SameBcHierarchyTable
+            : (props.widget.options
+                && (props.widget.options.hierarchy || props.widget.options.hierarchySameBc || props.widget.options.hierarchyFull)
+            )
+                ? (props.widget.options.hierarchyFull)
+                    ? <FullHierarchyTable
                         meta={props.widget}
                         assocValueKey={props.assocValueKey}
                         selectable
                     />
-                    : <HierarchyTable
-                        meta={props.widget}
-                        assocValueKey={props.assocValueKey}
-                        selectable
-                    />
+                    : (props.widget.options.hierarchySameBc)
+                        ? <SameBcHierarchyTable
+                            meta={props.widget}
+                            assocValueKey={props.assocValueKey}
+                            selectable
+                        />
+                        : <HierarchyTable
+                            meta={props.widget}
+                            assocValueKey={props.assocValueKey}
+                            selectable
+                        />
                 : <AssocTable
                     meta={props.widget}
                     disablePagination={true}

--- a/src/components/widgets/AssocListPopup/AssocTable.tsx
+++ b/src/components/widgets/AssocListPopup/AssocTable.tsx
@@ -24,7 +24,7 @@ export interface AssocTableProps extends AssocTableOwnProps {
 }
 
 export const AssocTable: FunctionComponent<AssocTableProps> = (props) => {
-    const [selectedRecords] = useAssocRecords(props.data, props.pendingChanges)
+    const selectedRecords = useAssocRecords(props.data, props.pendingChanges)
 
     const rowSelection: TableRowSelection<DataItem> = {
         type: 'checkbox',

--- a/src/epics/data.ts
+++ b/src/epics/data.ts
@@ -127,7 +127,9 @@ const bcFetchDataEpic: Epic = (action$, store) => action$.ofType(
         ...getFilters(filters),
         ...getSorters(sorters)
     }
-    if (action.type === types.bcFetchDataRequest && action.payload.ignorePageLimit) {
+    if (action.type === types.bcFetchDataRequest && action.payload.ignorePageLimit
+        || anyHierarchyWidget && anyHierarchyWidget.options.hierarchyFull
+    ) {
         fetchParams._limit = 0
     }
     const cancelFlow = action$.ofType(types.selectView).filter((item) => {
@@ -238,7 +240,8 @@ const bcSelectRecord: Epic = (action$, store) => action$.ofType(types.bcSelectRe
             return $do.bcFetchDataRequest({
                 bcName: childBcName,
                 widgetName: widgetNames[0],
-                ignorePageLimit: action.payload.ignoreChildrenPageLimit
+                ignorePageLimit: action.payload.ignoreChildrenPageLimit,
+                keepDelta: action.payload.keepDelta
             })
         })
     return Observable.concat(
@@ -534,6 +537,47 @@ const changeChildrenAssociationsSameBc: Epic = (action$, store) => action$.ofTyp
     }))
 })
 
+/**
+ * Change full hierarchy descendants association state.
+ *
+ * @param action$
+ * @param store
+ */
+const changeDescendantsAssociationsFull: Epic = (action$, store) => action$.ofType(types.changeDescendantsAssociationsFull)
+.mergeMap(action => {
+    const state = store.getState()
+    const depth = action.payload.depth
+    const data = state.data[action.payload.bcName]
+
+    const targetData = (data || []).filter((item) =>
+        item.level === depth && item.parentId === action.payload.parentId
+    )
+
+    const result: Array<Observable<AnyAction>> = [
+        Observable.of($do.changeDataItems({
+            bcName: action.payload.bcName,
+            cursors: targetData.map(item => item.id),
+            dataItems: targetData.map(item => ({
+                ...item,
+                _value: item[action.payload.assocValueKey],
+                _associate: action.payload.selected
+            }))
+        }))
+    ]
+
+    targetData.forEach((targetDataItem) => {
+        if (data.find((dataItem) => dataItem.parentId === targetDataItem.id)) {
+            result.push(Observable.of($do.changeDescendantsAssociationsFull({
+                ...action.payload,
+                parentId: targetDataItem.id,
+                depth: depth + 1
+            })))
+        }
+    })
+
+    return Observable.concat(...result)
+})
+
 const changeAssociation: Epic = (action$, store) => action$.ofType(types.changeAssociation)
 .mergeMap(action => {
     const state = store.getState()
@@ -673,6 +717,115 @@ const changeAssociationSameBc: Epic = (action$, store) => action$.ofType(types.c
 })
 
 /**
+ * Change full hierarchy record association state. Also select/deselect dependent records according to widget options.
+ *
+ * @param action$
+ * @param store
+ */
+const changeAssociationFull: Epic = (action$, store) => action$.ofType(types.changeAssociationFull)
+.mergeMap(action => {
+    const state = store.getState()
+    const result: Array<Observable<AnyAction>> = []
+
+    const bcName = action.payload.bcName
+    const allData = state.data[bcName]
+    const selected = action.payload.dataItem._associate
+    const depth = action.payload.depth || 1
+    const parentDepth = depth - 1
+    const parentItem = (depth > 1) && allData.find((item) => item.id === action.payload.dataItem.parentId)
+    const widget = state.view.widgets.find(item => item.name === action.payload.widgetName) as WidgetTableMeta
+    const hierarchyTraverse = widget.options.hierarchyTraverse
+    const rootRadio = widget.options.hierarchyRadio
+    const hierarchyGroupDeselection = widget.options.hierarchyGroupDeselection
+
+    const currentLevelData = allData.filter(
+        (item) => item.level === depth && (item.level === 1 || (parentItem && item.parentId === parentItem.id))
+    )
+
+    if (rootRadio && hierarchyGroupDeselection && depth === 1) {
+        if (selected) {
+            const delta = state.view.pendingDataChanges[bcName]
+            const prevSelected = allData.find((dataItem) => {
+                if (dataItem.level === 1 && dataItem.id !== action.payload.dataItem.id) {
+                    const deltaItem = delta && delta[dataItem.id]
+                    if (deltaItem && deltaItem._associate || !deltaItem && dataItem._associate) {
+                        return true
+                    }
+                }
+
+                return false
+            })
+
+            if (prevSelected) {
+                result.push(Observable.of($do.changeAssociationFull({
+                    bcName,
+                    depth: depth,
+                    widgetName: action.payload.widgetName,
+                    dataItem: { ...prevSelected, _associate: false },
+                    assocValueKey: action.payload.assocValueKey
+                })))
+            }
+        } else {
+            // result.push(Observable.of($do.dropAllAssociationsFull({bcName, depth: depth + 1, dropDescendants: true})))
+            result.push(Observable.of($do.changeDescendantsAssociationsFull({
+                bcName,
+                parentId: action.payload.dataItem.id,
+                depth: depth + 1,
+                assocValueKey: action.payload.assocValueKey,
+                selected: false
+            })))
+        }
+    }
+
+    result.push(Observable.of($do.changeDataItem({
+        bcName: action.payload.bcName,
+        cursor: action.payload.dataItem.id,
+        dataItem: action.payload.dataItem
+    })))
+
+    if (parentDepth && hierarchyTraverse && selected) {
+        result.push(Observable.of($do.changeAssociationFull({
+            bcName,
+            depth: parentDepth,
+            widgetName: action.payload.widgetName,
+            dataItem: {
+                ...parentItem,
+                _associate: true,
+                _value: parentItem[action.payload.assocValueKey]
+            },
+            assocValueKey: action.payload.assocValueKey
+        })))
+    }
+
+    if (parentDepth && hierarchyTraverse && !selected) {
+        const wasLastInData = currentLevelData
+            .filter(item => item.id !== action.payload.dataItem.id)
+            .every(item => !item._associate)
+
+        const delta = state.view.pendingDataChanges[bcName]
+        const wasLastInDelta = !delta
+            || !Object.values(delta).find((deltaValue) => {
+                return (
+                    deltaValue._associate === true && deltaValue.id !== action.payload.dataItem.id
+                    && currentLevelData.find((dataValue) => dataValue.id === deltaValue.id)
+                )
+            })
+
+        if (wasLastInData && wasLastInDelta) {
+            result.push(Observable.of($do.changeAssociationFull({
+                bcName,
+                depth: parentDepth,
+                widgetName: action.payload.widgetName,
+                dataItem: { ...parentItem, _associate: false },
+                assocValueKey: action.payload.assocValueKey
+            })))
+        }
+    }
+
+    return Observable.concat(...result)
+})
+
+/**
  * Возвращает словарь дочерних бизнес-компонент на текущей view
  * Ключ - имя дочерней бизнес-компоненты
  * Значение - массив идентификаторов виджетов, которые эту бизнес-компоненту используют.
@@ -780,6 +933,8 @@ export const dataEpics = combineEpics(
     changeAssociationSameBc,
     changeChildrenAssociations,
     changeChildrenAssociationsSameBc,
+    changeAssociationFull,
+    changeDescendantsAssociationsFull,
     bcLoadMore,
     removeMultivalueTag
 )

--- a/src/hooks/useAssocRecords.ts
+++ b/src/hooks/useAssocRecords.ts
@@ -6,9 +6,8 @@ const emptyData: AssociatedItem[] = []
 
 export function useAssocRecords(
     data: AssociatedItem[], pendingChanges: Record<string, PendingDataItem>, isRadio?: boolean
-): [AssociatedItem[] , React.Dispatch<React.SetStateAction<AssociatedItem[]>>] {
-    const [selectedRecords, setSelectedRecords] = React.useState(emptyData)
-    React.useEffect(() => {
+): AssociatedItem[] {
+    return React.useMemo(() => {
         let records = emptyData
         if (data) {
             records = data.filter(item => {
@@ -23,7 +22,6 @@ export function useAssocRecords(
                 return item._associate
             })
         }
-        setSelectedRecords(records)
+        return records
     }, [data, pendingChanges, isRadio])
-    return [selectedRecords, setSelectedRecords]
 }

--- a/src/interfaces/widget.ts
+++ b/src/interfaces/widget.ts
@@ -110,6 +110,10 @@ export type FileUploadFieldMeta = AllWidgetTypeFieldBase & {
     fileSource: string
 }
 
+export type HiddenFieldMeta = AllWidgetTypeFieldBase & {
+    type: FieldType.hidden
+}
+
 export type WidgetField = NumberFieldMeta
     | DateFieldMeta
     | DateTimeFieldMeta
@@ -123,6 +127,7 @@ export type WidgetField = NumberFieldMeta
     | InlinePickListFieldMeta
     | FileUploadFieldMeta
     | CheckboxFieldMeta
+    | HiddenFieldMeta
 
 export type WidgetFormField = Extract<WidgetField, WidgetFormFieldBase>
 
@@ -138,8 +143,10 @@ export interface WidgetOptions {
     },
     hierarchy?: WidgetTableHierarchy[],
     hierarchySameBc?: boolean,
+    hierarchyFull?: boolean,
     hierarchyParentKey?: string,
     hierarchyGroupSelection?: boolean,
+    hierarchyGroupDeselection?: boolean,
     hierarchyTraverse?: boolean,
     hierarchyRadio?: boolean,
     hierarchyRadioAll?: boolean,

--- a/src/reducers/view.ts
+++ b/src/reducers/view.ts
@@ -248,7 +248,38 @@ export function view(state = initialState, action: AnyAction, store: Store) {
                 pendingDataChanges[action.payload.bcName] = pendingBcChanges
             })
 
-            return { ...state, pendingDataChanges }
+            return {
+                ...state,
+                pendingDataChanges,
+                pendingValidationFails: initialState.pendingValidationFails
+            }
+        }
+        case types.dropAllAssociationsFull: {
+            const bcName = action.payload.bcName
+            const pendingDataChanges = {...state.pendingDataChanges}
+            const dropDesc = action.payload.dropDescendants
+
+            const pendingBcChanges: Record<string, PendingDataItem> = {};
+            (store.data[bcName] || [])
+                .filter(item => item._associate)
+                .forEach(item => {
+                    if (dropDesc && item.level === action.payload.depth || item.level >= action.payload.depth) {
+                        pendingBcChanges[item.id] = { ...item, _associate: false }
+                    }
+                })
+            Object.entries(pendingDataChanges[bcName] || {})
+                .forEach(([itemId, item]) => {
+                    if (dropDesc && item.level === action.payload.depth || item.level >= action.payload.depth) {
+                        pendingBcChanges[itemId] = { ...item, _associate: false }
+                    }
+                })
+            pendingDataChanges[bcName] = pendingBcChanges
+
+            return {
+                ...state,
+                pendingDataChanges,
+                pendingValidationFails: initialState.pendingValidationFails
+            }
         }
         case types.sendOperationSuccess:
         case types.bcSaveDataSuccess: {


### PR DESCRIPTION
"Full hierarchy" mode support for associate popup widget. Receives all BC records as plain list and shows it as hierarchy.  

Widget options flags:  
- **hierarchyFull** - Set Full Hierarchy mode for popup widget
- **hierarchyTraverse** - Select/Deselect all ancestors up to root when record is selected/deselected
- **hierarchyGroupSelection** - Select all descendants when record is selected
- **hierarchyGroupDeselection** - Deselect all descendants when record is deselected
- **hierarchyRadio** - Only one root record can be selected at the same time