### PR TITLE
Required fields validation

### DIFF
--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -13,6 +13,7 @@ import qs from 'query-string'
 import {initHistory} from './reducers/router'
 import {combineReducers} from './utils/redux'
 import {createAutoSaveMiddleware} from './middlewares/autosaveMiddleware'
+import {createRequiredFieldsMiddleware} from './middlewares/requiredFieldsMiddleware'
 import {initLocale} from './imports/i18n'
 import {Resource, i18n} from 'i18next'
 
@@ -91,6 +92,7 @@ export function configureStore<ClientState, ClientActions extends Action<any>>(
         }
     })
     const middlewares: Middleware[] = [
+        createRequiredFieldsMiddleware(),
         createAutoSaveMiddleware()
     ]
     if (useEpics) {

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {FunctionComponent} from 'react'
 import {connect} from 'react-redux'
 import {Dispatch} from 'redux'
 import {Input, Tooltip, Form} from 'antd'
@@ -57,9 +57,9 @@ export interface ChangeDataItemPayload { // TODO: Может из карты в 
 
 export const emptyMultivalue: MultivalueSingleValue[] = []
 
-export const Field = (props: FieldProps) => {
+export const Field: FunctionComponent<FieldProps> = (props) => {
     const [localValue, setLocalValue] = React.useState(null)
-    let resultField = null
+    let resultField: React.ReactChild = null
     // todo: временный фикс для корректной работы с пиклистами
     const undefinedValuesAllowed = [
         FieldType.pickList,
@@ -280,7 +280,7 @@ export const Field = (props: FieldProps) => {
             </ReadOnlyField>
             break
         default:
-            return <CustomizationContext.Consumer>
+            resultField = <CustomizationContext.Consumer>
                 {context => {
                     const customFields = context.customFields
                     if (customFields && (customFields[props.widgetFieldMeta.type] || customFields[props.widgetFieldMeta.key])) {
@@ -292,7 +292,7 @@ export const Field = (props: FieldProps) => {
                         />
                     }
 
-                    resultField = (props.readonly)
+                    return props.readonly
                         ? <ReadOnlyField
                             {...commonProps}
                             onDrillDown={handleDrilldown}
@@ -306,7 +306,7 @@ export const Field = (props: FieldProps) => {
                             onBlur={handleInputBlur}
                             autoFocus={props.forceFocus}
                         />
-                    return resultField
+
                 }}
             </CustomizationContext.Consumer>
     }

--- a/src/interfaces/operation.ts
+++ b/src/interfaces/operation.ts
@@ -38,15 +38,17 @@ export type OperationType = OperationTypeCrud | string
  * @param action - ???
  * @param scope - ???
  * @param preInvoke - действие, которое надо произвести прежде чем начать выполнять операцию
+ * @param autoSaveBefore Validate the record for empty "required" fields before API call
  */
 export interface Operation {
     text: string,
     type: OperationType,
     scope: OperationScope,
     action?: string,
-    icon?: string
-    showOnlyIcon: boolean
-    preInvoke?: OperationPreInvoke
+    icon?: string,
+    showOnlyIcon: boolean,
+    preInvoke?: OperationPreInvoke,
+    autoSaveBefore?: boolean
 }
 
 /**

--- a/src/middlewares/autosaveMiddleware.ts
+++ b/src/middlewares/autosaveMiddleware.ts
@@ -4,28 +4,16 @@ import {OperationTypeCrud} from '../interfaces/operation'
 import {WidgetMeta} from '../interfaces/widget'
 import {Store as CoreStore} from '../interfaces/store'
 import {buildBcUrl} from '../utils/strings'
-import {openButtonWarningNotification} from '../utils/notifications'
-import i18n from 'i18next'
 
-const saveFormMiddleware = ({ getState, dispatch }: MiddlewareAPI) =>
+const saveFormMiddleware = ({ getState, dispatch }: MiddlewareAPI<Dispatch<AnyAction>, CoreStore>) =>
     (next: Dispatch) =>
-        (action: AnyAction): any => {
+        (action: AnyAction) => {
             if (!needSaveAction(action.type)) {
                 return next(action)
             }
             const state = getState()
-            if (state.view.pendingValidationFails && Object.keys(state.view.pendingValidationFails).length) {
-                openButtonWarningNotification(
-                    i18n.t('Required fields are missing'),
-                    i18n.t('Cancel changes'),
-                    0,
-                    () => {
-                        dispatch($do.clearValidationFails(null))
-                    },
-                    'requiredFieldsMissing'
-                )
-                return
-            }
+
+            // TODO: Should offer to save pending changes or drop them
 
             const selectedCell = state.view.selectedCell
             if (selectedCell
@@ -64,7 +52,7 @@ function bcHasPendingAutosaveChanges(store: CoreStore, bcName: string, cursor: s
             && store.view.rowMeta[bcName]
             && store.view.rowMeta[bcName][bcUrl]
             && store.view.rowMeta[bcName][bcUrl].actions
-
+        // TODO: Shouldn't we check for nested operation if action oftype OperationGroup?
         result = actions && actions.some((action) => action.type === OperationTypeCrud.save)
     }
 

--- a/src/middlewares/requiredFieldsMiddleware.ts
+++ b/src/middlewares/requiredFieldsMiddleware.ts
@@ -1,0 +1,110 @@
+/**
+ * Handles validation of "required fields" for widget operations
+ */
+
+import {AnyAction, Dispatch, Middleware, MiddlewareAPI} from 'redux'
+import {$do, types, ActionPayloadTypes} from '../actions/actions'
+import {isOperationGroup, Operation, OperationGroup} from '../interfaces/operation'
+import {Store as CoreStore} from '../interfaces/store'
+import {buildBcUrl} from '../utils/strings'
+import {openButtonWarningNotification} from '../utils/notifications'
+import i18n from 'i18next'
+import {PendingDataItem, DataItem} from 'interfaces/data'
+import {RowMetaField} from 'interfaces/rowMeta'
+
+const requiredFields = ({ getState, dispatch }: MiddlewareAPI<Dispatch<AnyAction>, CoreStore>) => (next: Dispatch) =>
+(action: AnyAction) => {
+    const state = getState()
+    if (action.type === types.sendOperation) {
+        const { bcName, operationType } = action.payload as unknown as ActionPayloadTypes['sendOperation']
+        const cursor = state.screen.bo.bc[bcName] && state.screen.bo.bc[bcName].cursor
+        const bcUrl = buildBcUrl(bcName, true)
+        const record = state.data[bcName] && state.data[bcName].find(item => item.id === cursor)
+        const rowMeta = bcUrl
+            && state.view.rowMeta[bcName]
+            && state.view.rowMeta[bcName][bcUrl]
+        const pendingValues = state.view.pendingDataChanges[bcName]
+            && state.view.pendingDataChanges[bcName][cursor]
+
+        // If operation marked as validation-sensetive, mark all 'required' fields which haven't been filled as dirty and invalid
+        if (operationRequiresAutosave(operationType, rowMeta && rowMeta.actions)) {
+            const dataItem: PendingDataItem = getRequiredFieldsMissing(record, pendingValues, rowMeta && rowMeta.fields)
+            return dataItem
+                ? next($do.changeDataItem({ bcName, cursor, dataItem }))
+                : next(action)
+        }
+
+        // If operation is not validation-sensetive and validation failed, offer to drop pending changes
+        if (state.view.pendingValidationFails && Object.keys(state.view.pendingValidationFails).length) {
+            openButtonWarningNotification(
+                i18n.t('Required fields are missing'),
+                i18n.t('Cancel changes'),
+                0,
+                () => {
+                    next(($do.bcCancelPendingChanges(null)))
+                    next(($do.clearValidationFails(null)))
+                },
+                'requiredFieldsMissing'
+            )
+            return { type: types.emptyAction }
+        }
+    }
+
+    return next(action)
+}
+
+/**
+ * Check operations and operation groups for 'autoSaveBefore' flag (i.e. operation is validation-sensetive)
+ *
+ * @param operationType Key of operation to check
+ * @param actions List of operations and/or operation groups
+ */
+function operationRequiresAutosave(operationType: string, actions: (Operation | OperationGroup)[], ) {
+    let result = false
+    if (!actions) {
+        console.error('rowMeta is missing in the middle of "sendOperation" action')
+        return result
+    }
+    result = actions && actions.some(action => {
+        if (isOperationGroup(action)) {
+            return action.actions.find(item => item.type === operationType && item.autoSaveBefore)
+        } else {
+            return action.type === operationType && action.autoSaveBefore
+        }
+    })
+    return result
+}
+
+/**
+ * Check if required records fields have a falsy value.
+ * "Falsy" stands for "undefined", "null", "", [] and {}.
+ *
+ * @param record Record to check
+ * @param pendingChanges Pending record changes which could override record values
+ * @param rowMeta Fields meta to check for 'required' flag
+ */
+function getRequiredFieldsMissing(record: DataItem, pendingChanges: PendingDataItem, fieldsMeta: RowMetaField[]) {
+    const result: PendingDataItem = {}
+    fieldsMeta.forEach(field => {
+
+        const value = record && record[field.key] as string
+        const pendingValue = pendingChanges && pendingChanges[field.key]
+        const effectiveValue = pendingChanges !== undefined ? pendingValue as string: value
+        let falsyValue = false
+        if ([undefined, null, ''].includes(effectiveValue)) {
+            falsyValue = true
+        } else if (Array.isArray(effectiveValue) && !effectiveValue.length) {
+            falsyValue = true
+        } else if (effectiveValue && !Object.keys(effectiveValue).length) {
+            falsyValue = true
+        }
+        if (field.required && falsyValue) {
+            result[field.key] = null
+        }
+    })
+    return Object.keys(result).length > 0 ? result : null
+}
+
+export function createRequiredFieldsMiddleware() {
+    return requiredFields as Middleware
+}

--- a/src/reducers/view.ts
+++ b/src/reducers/view.ts
@@ -304,10 +304,10 @@ export function view(state = initialState, action: AnyAction, store: Store) {
             }
         }
         case types.bcCancelPendingChanges: {
-            // TODO: Неправильно работает, надо попробовать решить без ввода еще одной дельты
+            // TODO: Check if this works for hierarchy after 1.1.0
             const pendingDataChanges = { ...state.pendingDataChanges }
             for (const bcName in state.pendingDataChanges) {
-                if (action.payload.bcNames.includes(bcName)) {
+                if (action.payload ? action.payload.bcNames.includes(bcName) : true) {
                     pendingDataChanges[bcName] = {}
                 }
             }


### PR DESCRIPTION
See #1 

* New `requiredFieldsMiddleware` handles `required` fields when widget operation marked with "autoSaveBefore" flag have been requested
* Middlewares now work with correctly typed redux store
* As fields of unknown typed fallback to "input" type, the usual "input" fields and unknown custom fields are handled together. This leads to an error where invalid input fields do not show their validation error hint. 