### PR TITLE
Decompose <TableWidget /> and fix row menu showing incorrect operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# Version 1.5.0
+
+## Features
+
+* Template strings for field titles: Table and Form widgets now support templated title in form of `Title {token:defaultValue}` string, where `token` is replaced with value of the field with key `token` of the currently selected record. `<TemplatedTitle />` component now exported to support this behaviour is custom widgets (#94).
+* `<Pagination />` component now have `onChangePage` callback (#76).
+
+## Fixes
+
+* Hierarchy table should clear active cursor on page change (#76).
+
+## Misc
+
+* Disable check for the presence of `save` action in row meta for autosave middleware until we investigate the cases when this check fails due to missing cursor (#99).
+
 # Version 1.4.4
 
 ## Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tesler-ui/core",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "main": "tesler-ui-core.js",
   "homepage": "https://tesler.io/",
   "types": "index.d.ts",

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -783,16 +783,14 @@ export class ActionPayloadTypes {
     } = z
 
     /**
-     * TODO
-     * 
-     * @param bcName
      * @param cursor
-     * @param router
+     * @param bcName TODO: Use widgetName instead; remove in 2.0.0
+     * @param router TODO: Handled in epic instead; remove in 2.0.0
      */
     showAllTableRecordsInit: {
         bcName: string,
         cursor: string,
-        route: Route
+        route?: Route
     } = z
 
     /**

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1,6 +1,8 @@
 {
     "translation": {
         "Apply": "Apply",
-        "Clear": "Clear"
+        "Clear": "Clear",
+        "No operations available": "No operations available",
+        "Show other records": "Show other records"
     }
 }

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -4,6 +4,8 @@
         "Clear": "Сбросить",
         "Required fields are missing": "Не заполнены обязательные поля",
         "There are pending changes. Please save them or cancel.": "Остались несохраненные данные. Сохраните или отмените изменения.",
-        "Cancel changes": "Отменить изменения"
+        "Cancel changes": "Отменить изменения",
+        "No operations available": "Нет доступных операций",
+        "Show other records": "Показать остальные записи"
     }
 }

--- a/src/components/ColumnTitle/ColumnTitle.tsx
+++ b/src/components/ColumnTitle/ColumnTitle.tsx
@@ -4,6 +4,7 @@ import {WidgetListField} from '../../interfaces/widget'
 import ColumnFilter from './ColumnFilter'
 import ColumnSort from './ColumnSort'
 import styles from './ColumnTitle.less'
+import TemplatedTitle from '../TemplatedTitle/TemplatedTitle'
 
 export interface ColumnTitle {
     widgetName: string,
@@ -15,8 +16,12 @@ export const ColumnTitle: FunctionComponent<ColumnTitle> = (props) => {
     if (!props.widgetMeta && !props.rowMeta) {
         return null
     }
+    const title = <TemplatedTitle
+        widgetName={props.widgetName}
+        title={props.widgetMeta.title}
+    />
     if (!props.rowMeta) {
-        return <div>{props.widgetMeta.title}</div>
+        return <div>{title}</div>
     }
 
     const filterable = props.rowMeta.filterable
@@ -32,7 +37,7 @@ export const ColumnTitle: FunctionComponent<ColumnTitle> = (props) => {
             rowMeta={props.rowMeta}
         />
     return <div className={styles.container}>
-        {props.widgetMeta.title}
+        {title}
         {filter}
         {sort}
     </div>

--- a/src/components/HierarchyTable/HierarchyTable.tsx
+++ b/src/components/HierarchyTable/HierarchyTable.tsx
@@ -145,7 +145,7 @@ export const HierarchyTable: FunctionComponent<HierarchyTableProps> = (props) =>
             return props.data && props.data.map((item) => {
                 return {
                     ...item,
-                    noChildren: (currentCursor && noChildRecords.includes(item.id))
+                    noChildren: noChildRecords.includes(item.id)
                 }
             })
         },
@@ -174,6 +174,10 @@ export const HierarchyTable: FunctionComponent<HierarchyTableProps> = (props) =>
             setUserClosedRecords([ ...userClosedRecords, dataItem.id ])
         }
     }
+
+    const resetCursor = React.useCallback(() => {
+        setCurrentCursor(null)
+    }, [])
 
     // Вложенный уровень иерархии рисуется новой таблицей
     const nested = (record: DataItem, index: number, indent: number, expanded: boolean) => {
@@ -254,7 +258,8 @@ export const HierarchyTable: FunctionComponent<HierarchyTableProps> = (props) =>
             loading={props.loading}
             onRow={!(hierarchyDisableRoot && indentLevel === 0) && props.onRow}
         />
-        {props.showPagination && <Pagination bcName={bcName} mode={PaginationMode.page} />}
+        {props.showPagination &&
+        <Pagination bcName={bcName} mode={PaginationMode.page} onChangePage={resetCursor}/>}
     </div>
 }
 

--- a/src/components/TemplatedTitle/TemplatedTitle.tsx
+++ b/src/components/TemplatedTitle/TemplatedTitle.tsx
@@ -1,0 +1,35 @@
+import React, {FunctionComponent} from 'react'
+import {connect} from 'react-redux'
+import {Store} from '../../interfaces/store'
+import {getFieldTitle} from '../../utils/strings'
+
+interface TemplatedTitleOwnProps {
+    title: string,
+    widgetName: string,
+    container?: React.ComponentType<any>
+}
+
+interface TemplatedTitleProps extends TemplatedTitleOwnProps {
+    templatedTitle: string
+}
+
+export const TemplatedTitle: FunctionComponent<TemplatedTitleProps> = (props) => {
+    if (!props.title) {
+        return null
+    }
+    const wrapper = props.container && <props.container title={props.templatedTitle}/>
+    return wrapper || <> {props.templatedTitle} </>
+}
+
+function mapStateToProps(store: Store, ownProps: TemplatedTitleOwnProps) {
+    const widget = store.view.widgets.find(item => item.name === ownProps.widgetName)
+    const bcName = widget && widget.bcName
+    const bc = store.screen.bo.bc[bcName]
+    const cursor = bc && bc.cursor
+    const bcData = store.data[bcName]
+    const dataItem = bcData && bcData.find(item => item.id === cursor)
+    return {
+        templatedTitle: getFieldTitle(ownProps.title, dataItem)
+    }
+}
+export default connect(mapStateToProps)(TemplatedTitle)

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -13,6 +13,7 @@ export {default as CheckboxPicker} from './ui/CheckboxPicker/CheckboxPicker'
 export {default as Pagination} from './ui/Pagination/Pagination'
 export {default as ErrorPopup} from './ui/ErrorPopup/ErrorPopup'
 // Контейнеры
+export {default as TemplatedTitle} from './TemplatedTitle/TemplatedTitle'
 export {default as View} from './View/View'
 export {default as Widget} from './Widget/Widget'
 export {default as Field} from './Field/Field'

--- a/src/components/ui/Multivalue/MultivalueList.tsx
+++ b/src/components/ui/Multivalue/MultivalueList.tsx
@@ -6,7 +6,7 @@ import cn from 'classnames'
 import MultiValueListRecord from '../../Multivalue/MultiValueListRecord'
 
 interface MultivalueListOwnProps {
-    fieldTitle: string,
+    fieldTitle: React.ReactNode,
     field: MultivalueFieldMeta,
     data: MultivalueSingleValue[],
     isFloat: boolean,
@@ -16,7 +16,7 @@ interface MultivalueListOwnProps {
 
 const MultivalueList: React.FunctionComponent<MultivalueListOwnProps> = (props) => {
 
-    return <div key={`${props.field.key}_${props.fieldTitle}`} className={cn({
+    return <div key={`${props.field.key}_${props.field.label}`} className={cn({
         [styles.fieldAreaFloat]: props.isFloat,
         [styles.fieldAreaBase]: !props.isFloat,
         [styles.noFieldSeparator]: props.noLineSeparator,

--- a/src/components/ui/Pagination/Pagination.tsx
+++ b/src/components/ui/Pagination/Pagination.tsx
@@ -10,6 +10,7 @@ import {$do} from '../../../actions/actions'
 interface PaginationOwnProps {
     bcName: string
     mode: PaginationMode,
+    onChangePage?: () => void,
 }
 
 interface PaginationStateProps {
@@ -40,6 +41,9 @@ const Pagination: React.FunctionComponent<PaginationAllProps> = (props) => {
     const onPrevPage = React.useCallback(
         () => {
             props.changePage(props.bcName, props.page - 1)
+            if (props.onChangePage) {
+                props.onChangePage()
+            }
         },
         [props.bcName, props.page, props.changePage]
     )
@@ -47,6 +51,9 @@ const Pagination: React.FunctionComponent<PaginationAllProps> = (props) => {
     const onNextPage = React.useCallback(
         () => {
             props.changePage(props.bcName, props.page + 1)
+            if (props.onChangePage) {
+                props.onChangePage()
+            }
         },
         [props.bcName, props.page, props.changePage]
     )

--- a/src/components/widgets/FormWidget/FormWidget.tsx
+++ b/src/components/widgets/FormWidget/FormWidget.tsx
@@ -10,6 +10,7 @@ import {useFlatFormFields} from '../../../hooks/useFlatFormFields'
 import styles from './FormWidget.less'
 import cn from 'classnames'
 import {FieldType} from '../../../interfaces/view'
+import TemplatedTitle from '../../TemplatedTitle/TemplatedTitle'
 
 interface FormWidgetOwnProps {
     meta: WidgetFormMeta,
@@ -51,12 +52,17 @@ export const FormWidget: FunctionComponent<FormWidgetProps> = (props) => {
                         const field = flattenWidgetFields.find(item => item.key === col.fieldKey)
                         const error = (props.missingFields && props.missingFields[field.key])
                             || props.metaErrors && props.metaErrors[field.key]
-                        const fieldLabel = field.type === 'checkbox' ? null : field.label
                         return  <Col key={colIndex} span={col.span} className={cn(
                             {[styles.colWrapper]: row.cols.length > 1 || col.span !== 24}
                         )}>
                             <Form.Item
-                                label={fieldLabel}
+                                label={field.type === 'checkbox'
+                                    ? null
+                                    : <TemplatedTitle
+                                        widgetName={props.meta.name}
+                                        title={field.label}
+                                    />
+                                }
                                 validateStatus={error ? 'error' : undefined}
                                 help={error}
                             >

--- a/src/components/widgets/TableWidget/RowOperations.less
+++ b/src/components/widgets/TableWidget/RowOperations.less
@@ -1,0 +1,3 @@
+.floatMenuSkeletonWrapper {
+    width: 200px
+}

--- a/src/components/widgets/TableWidget/RowOperations.tsx
+++ b/src/components/widgets/TableWidget/RowOperations.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {Dispatch} from 'redux'
 import {connect} from 'react-redux'
+import {useTranslation} from 'react-i18next'
 import {Menu, Skeleton, Icon, Dropdown} from 'antd'
 import {$do} from '../../../actions/actions'
 import {useWidgetOperations} from '../../../hooks'
@@ -26,6 +27,7 @@ interface RowOperationProps extends RowOperationsOwnProps {
  * "More actions" button for per-row operations
  */
 export const RowOperations: React.FC<RowOperationProps> = (props) => {
+    const {t} = useTranslation()
     const handleExpand = React.useCallback(() => {
         props.onExpand(props.widgetMeta.bcName, props.selectedKey)
     }, [props.widgetMeta.bcName, props.selectedKey])
@@ -86,7 +88,7 @@ export const RowOperations: React.FC<RowOperationProps> = (props) => {
             : menuItemList.length
                 ? menuItemList
                 : <Menu.Item disabled>
-                    Нет доступных операций
+                    {t('No operations available')}
                 </Menu.Item>
         }
     </Menu>

--- a/src/components/widgets/TableWidget/RowOperations.tsx
+++ b/src/components/widgets/TableWidget/RowOperations.tsx
@@ -1,0 +1,126 @@
+import React from 'react'
+import {Dispatch} from 'redux'
+import {connect} from 'react-redux'
+import {Menu, Skeleton, Icon, Dropdown} from 'antd'
+import {$do} from '../../../actions/actions'
+import {useWidgetOperations} from '../../../hooks'
+import {buildBcUrl} from '../../../utils/strings'
+import {Operation, OperationGroup} from '../../../interfaces/operation'
+import {WidgetTableMeta} from '../../../interfaces/widget'
+import {Store} from '../../../interfaces/store'
+import styles from './RowOperations.less'
+
+interface RowOperationsOwnProps {
+    widgetMeta: WidgetTableMeta,
+    selectedKey?: string
+}
+
+interface RowOperationProps extends RowOperationsOwnProps {
+    operations: Array<Operation | OperationGroup>,
+    metaInProgress: boolean,
+    onOperationClick: (bcName: string, operationType: string, widgetName: string) => void,
+    onExpand: (bcName: string, cursor: string) => void
+}
+
+/**
+ * "More actions" button for per-row operations
+ */
+export const RowOperations: React.FC<RowOperationProps> = (props) => {
+    const handleExpand = React.useCallback(() => {
+        props.onExpand(props.widgetMeta.bcName, props.selectedKey)
+    }, [props.widgetMeta.bcName, props.selectedKey])
+
+    const operations = useWidgetOperations(props.operations, props.widgetMeta)
+    const menuItemList: React.ReactNode[] = []
+
+    operations.forEach((item: Operation | OperationGroup) => {
+        if ((item as OperationGroup).actions) {
+            const groupOperations: React.ReactNode[] = [];
+            (item as OperationGroup).actions.forEach(operation => {
+                if (operation.scope === 'record') {
+                    groupOperations.push(
+                        <Menu.Item
+                            key={operation.type}
+                            onClick={() => {
+                                props.onOperationClick(props.widgetMeta.bcName, operation.type, props.widgetMeta.name)
+                            }}
+                        >
+                            { operation.icon && <Icon type={operation.icon} /> }
+                            { operation.text }
+                        </Menu.Item>
+                    )
+                }
+            })
+            if (groupOperations.length) {
+                menuItemList.push(
+                    <Menu.ItemGroup key={item.type || item.text} title={item.text}>
+                        {groupOperations.map((v) => v)}
+                    </Menu.ItemGroup>
+                )
+            }
+        }
+
+        const ungroupedOperation = (item as Operation)
+        if (ungroupedOperation.scope === 'record') {
+            menuItemList.push(
+                <Menu.Item
+                    key={item.type}
+                    onClick={() => {
+                        props.onOperationClick(props.widgetMeta.bcName, ungroupedOperation.type, props.widgetMeta.name)
+                    }}
+                >
+                    { ungroupedOperation.icon && <Icon type={ungroupedOperation.icon} /> }
+                    {item.text}
+                </Menu.Item>
+            )
+        }
+    })
+
+    const overlay = <Menu>
+        { props.metaInProgress
+            ? <Menu.Item disabled>
+                <div className={styles.floatMenuSkeletonWrapper}>
+                    <Skeleton active />
+                </div>
+            </Menu.Item>
+            : menuItemList.length
+                ? menuItemList
+                : <Menu.Item disabled>
+                    Нет доступных операций
+                </Menu.Item>
+        }
+    </Menu>
+
+    return <Dropdown
+        trigger={['click']}
+        overlay={overlay}
+        getPopupContainer={trigger => trigger.parentElement}
+    >
+        <Icon type="more" onClick={handleExpand} />
+    </Dropdown>
+}
+
+function mapStateToProps(store: Store, ownProps: RowOperationsOwnProps) {
+    const bcName = ownProps.widgetMeta.bcName
+    const bcUrl = buildBcUrl(bcName, true)
+    const operations = store.view.rowMeta[bcName]
+        && store.view.rowMeta[bcName][bcUrl]
+        && store.view.rowMeta[bcName][bcUrl].actions
+    return {
+        operations,
+        metaInProgress: !!store.view.metaInProgress[bcName]
+    }
+}
+
+function mapDispatchToProps(dispatch: Dispatch) {
+    return {
+        onOperationClick: (bcName: string, operationType: string, widgetName: string) => {
+            dispatch($do.sendOperation({ bcName, operationType, widgetName }))
+        },
+        onExpand: (bcName: string, cursor: string) => {
+            dispatch($do.bcSelectRecord({ bcName, cursor }))
+        }
+    }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(RowOperations)

--- a/src/components/widgets/TableWidget/TableRow.less
+++ b/src/components/widgets/TableWidget/TableRow.less
@@ -1,0 +1,26 @@
+.controls {
+    position: relative;
+}
+
+.trigger {
+    display: none;
+    top: 10px;
+    position: absolute;
+    right: 16px;
+    width: 24px;
+    height: 24px;
+    text-align: center;
+    border-radius: 50%;
+    z-index: 1000;
+    cursor: pointer;
+    background: transparent;
+    font-size: 28px;
+}
+
+.trigger:hover {
+    color: #0088bb;
+}
+
+.row:hover .trigger {
+    display: initial;
+}

--- a/src/components/widgets/TableWidget/TableRow.less
+++ b/src/components/widgets/TableWidget/TableRow.less
@@ -22,5 +22,5 @@
 }
 
 .row:hover .trigger {
-    display: initial;
+    display: block;
 }

--- a/src/components/widgets/TableWidget/TableRow.tsx
+++ b/src/components/widgets/TableWidget/TableRow.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import cn from 'classnames'
+import styles from './TableRow.less'
+
+export interface AntTableRowProps {
+    /**
+     * Unique key for the row
+     */
+    'data-row-key': string,
+    /**
+     * Original row content, usually <td> elements
+     */
+    children: React.ReactChildren
+    /**
+     * Will be combined with internal class and passed to root element
+     */
+    className?: string,
+    /**
+     * Will be passed to root element
+     */
+    style?: React.CSSProperties,
+    /**
+     * Will be passed to root element
+     */
+    onMouseEnter?: (e: React.MouseEvent<HTMLTableRowElement>) => void,
+    /**
+     * Will be passed to root element
+     */
+    onMouseLeave?: (e: React.MouseEvent<HTMLTableRowElement>) => void,
+    /**
+     * Will be passed to root element
+     */
+    onClick?: (e: React.MouseEvent<HTMLTableRowElement>) => void,
+    /**
+     * Will be passed to root element
+     */
+    onContextMenu?: () => void
+}
+
+export interface TableRowProps extends AntTableRowProps {
+    /**
+     * Component which will be dispayed in controls column on row hover
+     */
+    operations?: React.ReactNode
+}
+
+/**
+ * M<tr> element extended with common row handlers and additional column for controls.
+ */
+export const TableRow: React.FC<TableRowProps> = (props) => {
+    const { children, className, operations, onMouseEnter, onMouseLeave, ...rest } = props
+
+    return <tr className={cn(styles.row, props.className)} {...rest}>
+        {props.children}
+        { props.operations &&
+            <td className={styles.controls}>
+                <div className={styles.trigger}>
+                    {props.operations}
+                </div>
+            </td>
+        }
+    </tr>
+}
+
+export default React.memo(TableRow)

--- a/src/components/widgets/TableWidget/TableWidget.less
+++ b/src/components/widgets/TableWidget/TableWidget.less
@@ -33,31 +33,3 @@
         padding-right: 30px;
     }
 }
-
-.floatMenu {
-    display: none;
-    position: absolute;
-    right: 5px;
-    width: 24px;
-    height: 24px;
-    text-align: center;
-    border-radius: 50%;
-    z-index: 1000;
-    cursor: pointer;
-    background: #fff;
-}
-
-.showMenu {
-    display: block;
-}
-
-.dots {
-    font-size: 30px;
-    height: 100%;
-    line-height: 7px;
-    color: #000;
-}
-
-.floatMenuSkeletonWrapper {
-    width: 200px
-}

--- a/src/components/widgets/TableWidget/TableWidget.tsx
+++ b/src/components/widgets/TableWidget/TableWidget.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent } from 'react'
 import {connect} from 'react-redux'
 import {Dispatch} from 'redux'
+import {useTranslation} from 'react-i18next'
 import {Table} from 'antd'
 import {ColumnProps, TableRowSelection} from 'antd/es/table'
 import ActionLink from '../../ui/ActionLink/ActionLink'
@@ -59,6 +60,7 @@ interface TableWidgetProps extends TableWidgetOwnProps {
 }
 
 export const TableWidget: FunctionComponent<TableWidgetProps> = (props) => {
+    const {t} = useTranslation()
     // Switch to hierarchy mode if necessary
     if (props.meta.options && props.meta.options.hierarchy) {
         return <HierarchyTable meta={props.meta} showPagination />
@@ -129,7 +131,7 @@ export const TableWidget: FunctionComponent<TableWidgetProps> = (props) => {
     return <div className={styles.tableContainer}>
         { props.limitBySelf &&
             <ActionLink onClick={() => props.onShowAll(props.meta.bcName, props.cursor)}>
-                Показать остальные записи
+                {t('Show other records')}
             </ActionLink>
         }
         <Table

--- a/src/components/widgets/TableWidget/TableWidget.tsx
+++ b/src/components/widgets/TableWidget/TableWidget.tsx
@@ -1,13 +1,7 @@
 import React, { FunctionComponent } from 'react'
 import {connect} from 'react-redux'
 import {Dispatch} from 'redux'
-import {
-    Table,
-    Menu,
-    Dropdown,
-    Icon,
-    Skeleton
-} from 'antd'
+import {Table} from 'antd'
 import {ColumnProps, TableRowSelection} from 'antd/es/table'
 import ActionLink from '../../ui/ActionLink/ActionLink'
 import {$do} from '../../../actions/actions'
@@ -21,13 +15,14 @@ import {FieldType, ViewSelectedCell} from '../../../interfaces/view'
 import Field, {emptyMultivalue} from '../../Field/Field'
 import MultivalueHover from '../../ui/Multivalue/MultivalueHover'
 import {Route} from '../../../interfaces/router'
-import {useWidgetOperations} from '../../../hooks'
-import {Operation, OperationGroup} from '../../../interfaces/operation'
 import ColumnTitle from '../../ColumnTitle/ColumnTitle'
 import cn from 'classnames'
 import Pagination from '../../ui/Pagination/Pagination'
 import {PaginationMode} from '../../../interfaces/widget'
 import HierarchyTable from '../../../components/HierarchyTable/HierarchyTable'
+import RowOperations from './RowOperations'
+import TableRow, {AntTableRowProps} from './TableRow'
+import {Operation, OperationGroup} from '../../../interfaces/operation'
 
 interface TableWidgetOwnProps {
     meta: WidgetTableMeta,
@@ -42,312 +37,115 @@ interface TableWidgetProps extends TableWidgetOwnProps {
     data: DataItem[],
     rowMetaFields: RowMetaField[],
     limitBySelf: boolean,
-    bcName: string,
     route: Route,
     cursor: string,
     selectedCell: ViewSelectedCell,
-    pendingDataItem: PendingDataItem,
     hasNext: boolean,
-    operations: Array<Operation | OperationGroup>,
-    metaInProgress: boolean,
-    onDrillDown: (widgetName: string, bcName: string, cursor: string, fieldKey: string) => void,
     onShowAll: (bcName: string, cursor: string, route: Route) => void,
-    onOperationClick: (bcName: string, operationType: string, widgetName: string) => void,
-    onSelectRow: (bcName: string, cursor: string) => void,
     onSelectCell: (cursor: string, widgetName: string, fieldKey: string) => void,
+    /**
+     * @deprecated TODO: Properties below not used anymore and will be removed in 2.0.0
+     */
+    bcName?: string, // Use meta.bcName instead
+    operations?: Array<Operation | OperationGroup>,
+    metaInProgress?: boolean,
+    pendingDataItem?: PendingDataItem,
+    onOperationClick?: (bcName: string, operationType: string, widgetName: string) => void,
+    onSelectRow?: (bcName: string, cursor: string) => void
+    onDrillDown?: (widgetName: string, bcName: string, cursor: string, fieldKey: string) => void,
 }
 
 export const TableWidget: FunctionComponent<TableWidgetProps> = (props) => {
-
+    // Switch to hierarchy mode if necessary
     if (props.meta.options && props.meta.options.hierarchy) {
-        return <HierarchyTable
-            meta={props.meta}
-            showPagination
-        />
+        return <HierarchyTable meta={props.meta} showPagination />
     }
-
-    // Набор рефов для работы меню операций строки
-    const floatMenuRef = React.useRef(null)
-    const tableContainerRef = React.useRef(null)
-    const tableBodyRef = React.useRef(null)
-    const floatMenuHoveredRecord = React.useRef('')
-    const floatMenuIsOpened = React.useRef(false)
-    const mouseAboveRow = React.useRef(false)
-    const expectedFloatMenuTopValue = React.useRef('') // положение меню, которое должно быть выставлено после закрытия
-
-    const onTableMouseEnter = React.useCallback(
-        () => {
-            if (floatMenuRef.current) {
-                floatMenuRef.current.classList.add(styles.showMenu)
-            }
-        },
-        []
-    )
-
-    const onTableMouseLeave = React.useCallback(
-        (event: React.MouseEvent<HTMLElement>) => {
-            if (!floatMenuIsOpened.current && floatMenuRef.current) {
-                if (event.relatedTarget) {
-                    let checkElement = event.relatedTarget as HTMLElement
-                    while (checkElement) {
-                        if (checkElement === floatMenuRef.current) {
-                            return
-                        }
-                        checkElement = checkElement.parentElement
-                    }
-                }
-
-                floatMenuRef.current.classList.remove(styles.showMenu)
-            }
-        },
-        []
-    )
-
-    const onFloatMenuMouseLeave = React.useCallback(
-        (event: React.MouseEvent<HTMLElement>) => {
-            if (!floatMenuIsOpened.current && tableBodyRef.current) {
-                if (event.relatedTarget) {
-                    let checkElement = event.relatedTarget as HTMLElement
-                    while (checkElement) {
-                        if (checkElement === tableBodyRef.current) {
-                            return
-                        }
-                        checkElement = checkElement.parentElement
-                    }
-                }
-
-                floatMenuRef.current.classList.remove(styles.showMenu)
-            }
-        },
-        []
-    )
-
-    React.useEffect(() => {
-        if (tableContainerRef.current) {
-            const table = tableContainerRef.current.querySelector('.ant-table-tbody')
-            if (table) {
-                tableBodyRef.current = table
-                if (!table.onmouseenter) {
-                    table.onmouseenter = onTableMouseEnter
-                }
-                if (!table.onmouseleave) {
-                    table.onmouseleave = onTableMouseLeave
-                }
+    // Customize row component to show operations hover
+    const tableComponents = React.useMemo(() => ({
+        body: {
+            row: (rowProps: AntTableRowProps) => {
+                const popup = props.showRowActions
+                    ? <RowOperations selectedKey={rowProps['data-row-key']} widgetMeta={props.meta} />
+                    : null
+                return <TableRow {...rowProps} operations={popup} />
             }
         }
-    }, [])
-
-    const onTableRow = React.useCallback(
-        (record, index) => {
-            return {
-                onMouseEnter: (event: React.MouseEvent<HTMLElement>) => {
-                    mouseAboveRow.current = true
-
-                    if (!floatMenuRef.current || !tableContainerRef.current) {
-                        return
-                    }
-
-                    const tableRow = event.currentTarget
-                    const tableContainerRect = tableContainerRef.current.getBoundingClientRect()
-                    const tableRowRect = tableRow.getBoundingClientRect()
-
-                    const floatMenuTopValue = `${tableRowRect.top - tableContainerRect.top + 17}px`
-                    expectedFloatMenuTopValue.current = floatMenuTopValue
-
-                    if (!floatMenuIsOpened.current) {
-                        floatMenuRef.current.style.top = floatMenuTopValue
-                        floatMenuHoveredRecord.current = record.id
-                    }
-                },
-                onMouseLeave: () => {
-                    mouseAboveRow.current = false
+    }), [props.meta, props.showRowActions])
+    // Create columns (TODO: Memoize)
+    const visibleFields = props.meta.fields.filter((item: WidgetListField) => item.type !== FieldType.hidden)
+    const columns: Array<ColumnProps<DataItem>> = visibleFields.map((item: WidgetListField, index) => {
+        const fieldRowMeta = props.rowMetaFields && props.rowMetaFields.find(field => field.key === item.key)
+        const lastColumn = visibleFields.length - 1 === index
+        return {
+            title: <ColumnTitle
+                widgetName={props.meta.name}
+                widgetMeta={item}
+                rowMeta={fieldRowMeta}
+            />,
+            key: item.key,
+            dataIndex: item.key,
+            width: item.width,
+            colSpan: props.showRowActions && lastColumn ? 2 : undefined,
+            render: (text, dataItem) => {
+                if (item.type === FieldType.multivalue) {
+                    return <MultivalueHover
+                        data={(dataItem[item.key] || emptyMultivalue) as MultivalueSingleValue[]}
+                        displayedValue={item.displayedKey && dataItem[item.displayedKey]}
+                    />
                 }
-            }
-        },
-        []
-    )
 
-    const onMenuVisibilityChange = React.useCallback(
-        (visibility: boolean) => {
-            floatMenuIsOpened.current = visibility
-            if (visibility) {
-                if (floatMenuHoveredRecord.current && floatMenuHoveredRecord.current !== props.cursor) {
-                    props.onSelectRow(props.bcName, floatMenuHoveredRecord.current)
-                }
-            } else {
-                if (!mouseAboveRow.current) {
-                    floatMenuRef.current.classList.remove(styles.showMenu)
-                } else if (expectedFloatMenuTopValue.current) {
-                    floatMenuRef.current.style.top = expectedFloatMenuTopValue.current
-                }
-            }
-        },
-        [props.cursor, props.onSelectRow, props.bcName, props.meta.name]
-    )
+                const editMode = props.allowEdit && (props.selectedCell && item.key === props.selectedCell.fieldKey
+                    && props.meta.name === props.selectedCell.widgetName && dataItem.id === props.selectedCell.rowId
+                    && props.cursor === props.selectedCell.rowId
+                )
 
-    const operations = useWidgetOperations(props.operations, props.meta)
-
-    const rowActionsMenu = React.useMemo(
-        () => {
-            const menuItemList: React.ReactNode[] = []
-            operations.forEach((item: Operation | OperationGroup, index) => {
-                if ((item as OperationGroup).actions) {
-                    const groupOperations: React.ReactNode[] = [];
-                    (item as OperationGroup).actions.forEach(operation => {
-                        if (operation.scope === 'record') {
-                            groupOperations.push(
-                                <Menu.Item
-                                    key={operation.type}
-                                    onClick={() => {
-                                        props.onOperationClick(props.bcName, operation.type, props.meta.name)
-                                    }}
-                                >
-                                    { operation.icon && <Icon type={operation.icon} className={styles.icon} /> }
-                                    {operation.text}
-                                </Menu.Item>
-                            )
+                return <div>
+                    <Field
+                        data={dataItem}
+                        bcName={props.meta.bcName}
+                        cursor={dataItem.id}
+                        widgetName={props.meta.name}
+                        widgetFieldMeta={item}
+                        readonly={!editMode}
+                        forceFocus={editMode}
+                    />
+                </div>
+            },
+            onCell: record => {
+                return !props.allowEdit
+                    ? null
+                    : {
+                        onDoubleClick: (event) => {
+                            props.onSelectCell(record.id, props.meta.name, item.key)
                         }
-                    })
-                    if (groupOperations.length) {
-                        menuItemList.push(
-                            <Menu.ItemGroup key={item.type || item.text} title={item.text}>
-                                {groupOperations.map((v) => v)}
-                            </Menu.ItemGroup>
-                        )
                     }
-                }
-
-                const ungroupedOperation = (item as Operation)
-                if (ungroupedOperation.scope === 'record') {
-                    menuItemList.push(
-                        <Menu.Item
-                            key={item.type}
-                            onClick={() => {
-                                floatMenuIsOpened.current = false
-                                props.onOperationClick(props.bcName, ungroupedOperation.type, props.meta.name)
-                            }}
-                        >
-                            { ungroupedOperation.icon && <Icon type={ungroupedOperation.icon} className={styles.icon} /> }
-                            {item.text}
-                        </Menu.Item>
-                    )
-                }
-            })
-
-            return <Menu>
-                {(props.metaInProgress)
-                    ? <Menu.Item disabled>
-                        <div className={styles.floatMenuSkeletonWrapper}>
-                            <Skeleton active />
-                        </div>
-                    </Menu.Item>
-                    : (menuItemList.length)
-                        ? menuItemList.map((item) => {
-                            return item
-                        })
-                        : <Menu.Item disabled>
-                            Нет доступных операций
-                        </Menu.Item>
-                }
-            </Menu>
-        },
-        [operations, props.meta.name, props.onOperationClick, props.bcName, props.metaInProgress]
-    )
-
-    const processCellClick = (recordId: string, fieldKey: string) => {
-        props.onSelectCell(recordId, props.meta.name, fieldKey)
-    }
-
-    const columns: Array<ColumnProps<DataItem>> = props.meta.fields
-        .filter((item: WidgetListField) => item.type !== FieldType.hidden)
-        .map((item: WidgetListField) => {
-            const fieldRowMeta = props.rowMetaFields && props.rowMetaFields.find(field => field.key === item.key)
-            return {
-                title: <ColumnTitle
-                    widgetName={props.meta.name}
-                    widgetMeta={item}
-                    rowMeta={fieldRowMeta}
-                />,
-                key: item.key,
-                dataIndex: item.key,
-                width: item.width,
-                render: (text, dataItem) => {
-                    if (item.type === FieldType.multivalue) {
-                        return <MultivalueHover
-                            data={(dataItem[item.key] || emptyMultivalue) as MultivalueSingleValue[]}
-                            displayedValue={item.displayedKey && dataItem[item.displayedKey]}
-                        />
-                    }
-
-                    const editMode = props.allowEdit && (props.selectedCell && item.key === props.selectedCell.fieldKey
-                        && props.meta.name === props.selectedCell.widgetName && dataItem.id === props.selectedCell.rowId
-                        && props.cursor === props.selectedCell.rowId
-                    )
-
-                    return <div>
-                        <Field
-                            data={dataItem}
-                            bcName={props.meta.bcName}
-                            cursor={dataItem.id}
-                            widgetName={props.meta.name}
-                            widgetFieldMeta={item}
-                            readonly={!editMode}
-                            forceFocus={editMode}
-                        />
-                    </div>
-                },
-                onCell: (record, rowIndex) => {
-                    return (!props.allowEdit)
-                        ? null
-                        : {
-                            onDoubleClick: (event) => {
-                                processCellClick(record.id, item.key)
-                            }
-                        }
-                }
             }
-        })
+        }
+    })
 
-    const handleShowAll = () => {
-        props.onShowAll(props.bcName, props.cursor, props.route)
-    }
-
-    return <div
-        className={styles.tableContainer}
-        ref={tableContainerRef}
-    >
+    return <div className={styles.tableContainer}>
         { props.limitBySelf &&
-            <ActionLink onClick={handleShowAll}>Показать остальные записи</ActionLink>
+            <ActionLink onClick={() => props.onShowAll(props.meta.bcName, props.cursor, props.route)}>
+                Показать остальные записи
+            </ActionLink>
         }
         <Table
             className={cn(
                 styles.table,
-                {[styles.tableWithRowMenu]: props.showRowActions}
+                { [styles.tableWithRowMenu]: props.showRowActions }
             )}
+            components={tableComponents}
             columns={columns}
             dataSource={props.data}
             rowKey="id"
             rowSelection={props.rowSelection}
             pagination={false}
-            onRow={(props.showRowActions) ? onTableRow : null}
         />
-        {!props.disablePagination && <Pagination bcName={props.bcName} mode={props.paginationMode || PaginationMode.page} />}
-        {(props.showRowActions) &&
-        <div
-            ref={floatMenuRef}
-            className={styles.floatMenu}
-            onMouseLeave={onFloatMenuMouseLeave}
-        >
-            <Dropdown
-                placement="bottomRight"
-                trigger={['click']}
-                onVisibleChange={onMenuVisibilityChange}
-                overlay={rowActionsMenu}
-                getPopupContainer={trigger => trigger.parentElement}
-            >
-                <div className={styles.dots}>...</div>
-            </Dropdown>
-        </div>
+        { !props.disablePagination &&
+            <Pagination
+                bcName={props.meta.bcName}
+                mode={props.paginationMode || PaginationMode.page}
+            />
         }
     </div>
 }
@@ -363,21 +161,14 @@ function mapStateToProps(store: Store, ownProps: TableWidgetOwnProps) {
     const cursor = bc && bc.cursor
     const hasNext = bc && bc.hasNext
     const limitBySelf = cursor && store.router.bcPath && store.router.bcPath.includes(`${bcName}/${cursor}`)
-    const operations = store.view.rowMeta[bcName]
-        && store.view.rowMeta[bcName][bcUrl]
-        && store.view.rowMeta[bcName][bcUrl].actions
     return {
         data: store.data[ownProps.meta.bcName],
         rowMetaFields: fields,
         limitBySelf,
-        bcName,
         route: store.router,
         cursor,
         hasNext,
-        selectedCell: store.view.selectedCell,
-        pendingDataItem: cursor && store.view.pendingDataChanges[bcName] && store.view.pendingDataChanges[bcName][cursor],
-        operations,
-        metaInProgress: !!store.view.metaInProgress[bcName]
+        selectedCell: store.view.selectedCell
     }
 }
 
@@ -388,16 +179,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
         },
         onShowAll: (bcName: string, cursor: string, route: Route) => {
             dispatch($do.showAllTableRecordsInit({ bcName, cursor, route }))
-        },
-        onDrillDown: (widgetName: string, cursor: string, bcName: string, fieldKey: string) => {
-            dispatch($do.userDrillDown({widgetName, cursor, bcName, fieldKey}))
-        },
-        onOperationClick: (bcName: string, operationType: string, widgetName: string) => {
-            dispatch($do.sendOperation({ bcName, operationType, widgetName }))
-        },
-        onSelectRow: (bcName: string, cursor: string) => {
-            dispatch($do.bcSelectRecord({ bcName, cursor }))
-        },
+        }
     }
 }
 

--- a/src/components/widgets/TableWidget/TableWidget.tsx
+++ b/src/components/widgets/TableWidget/TableWidget.tsx
@@ -37,16 +37,19 @@ interface TableWidgetProps extends TableWidgetOwnProps {
     data: DataItem[],
     rowMetaFields: RowMetaField[],
     limitBySelf: boolean,
-    route: Route,
     cursor: string,
     selectedCell: ViewSelectedCell,
     hasNext: boolean,
-    onShowAll: (bcName: string, cursor: string, route: Route) => void,
+    /**
+     * TODO: `route` arg now handled in epics, remove in 2.0.0
+     */
+    onShowAll: (bcName: string, cursor: string, route?: Route) => void,
     onSelectCell: (cursor: string, widgetName: string, fieldKey: string) => void,
     /**
      * @deprecated TODO: Properties below not used anymore and will be removed in 2.0.0
      */
     bcName?: string, // Use meta.bcName instead
+    route?: Route, // Handled in epic
     operations?: Array<Operation | OperationGroup>,
     metaInProgress?: boolean,
     pendingDataItem?: PendingDataItem,
@@ -125,7 +128,7 @@ export const TableWidget: FunctionComponent<TableWidgetProps> = (props) => {
 
     return <div className={styles.tableContainer}>
         { props.limitBySelf &&
-            <ActionLink onClick={() => props.onShowAll(props.meta.bcName, props.cursor, props.route)}>
+            <ActionLink onClick={() => props.onShowAll(props.meta.bcName, props.cursor)}>
                 Показать остальные записи
             </ActionLink>
         }
@@ -165,7 +168,6 @@ function mapStateToProps(store: Store, ownProps: TableWidgetOwnProps) {
         data: store.data[ownProps.meta.bcName],
         rowMetaFields: fields,
         limitBySelf,
-        route: store.router,
         cursor,
         hasNext,
         selectedCell: store.view.selectedCell
@@ -177,8 +179,8 @@ function mapDispatchToProps(dispatch: Dispatch) {
         onSelectCell: (cursor: string, widgetName: string, fieldKey: string) => {
             dispatch($do.selectTableCellInit({ widgetName, rowId: cursor, fieldKey }))
         },
-        onShowAll: (bcName: string, cursor: string, route: Route) => {
-            dispatch($do.showAllTableRecordsInit({ bcName, cursor, route }))
+        onShowAll: (bcName: string, cursor: string, route?: Route) => {
+            dispatch($do.showAllTableRecordsInit({ bcName, cursor }))
         }
     }
 }

--- a/src/epics/view.ts
+++ b/src/epics/view.ts
@@ -194,8 +194,8 @@ const showAllTableRecordsInit: Epic = (action$, store) => action$.ofType(types.s
 .mergeMap((action) => {
     const resultObservables: Array<Observable<AnyAction>> = []
 
-    const {bcName, route, cursor} = action.payload
-
+    const {bcName, cursor} = action.payload
+    const route = store.getState().router
     resultObservables.push(Observable.of(
         $do.bcChangeCursors({ cursorsMap: { [bcName]: null }})
     ))

--- a/src/middlewares/autosaveMiddleware.ts
+++ b/src/middlewares/autosaveMiddleware.ts
@@ -3,7 +3,6 @@ import {$do, needSaveAction, types} from '../actions/actions'
 import {OperationTypeCrud} from '../interfaces/operation'
 import {WidgetMeta} from '../interfaces/widget'
 import {Store as CoreStore} from '../interfaces/store'
-import {buildBcUrl} from '../utils/strings'
 
 const saveFormMiddleware = ({ getState, dispatch }: MiddlewareAPI<Dispatch<AnyAction>, CoreStore>) =>
     (next: Dispatch) =>
@@ -51,19 +50,8 @@ export function createAutoSaveMiddleware() {
  * @param cursor 
  */
 function bcHasPendingAutosaveChanges(store: CoreStore, bcName: string, cursor: string) {
-    let result = false
-
     const pendingChanges = store.view.pendingDataChanges
     const cursorChanges = pendingChanges[bcName] && pendingChanges[bcName][cursor]
-    if (cursorChanges && !Object.keys(cursorChanges).includes('_associate') && Object.values(cursorChanges).length) {
-        const bcUrl = buildBcUrl(bcName, true)
-        const actions = bcUrl
-            && store.view.rowMeta[bcName]
-            && store.view.rowMeta[bcName][bcUrl]
-            && store.view.rowMeta[bcName][bcUrl].actions
-        // TODO: Shouldn't we check for nested operation if action oftype OperationGroup?
-        result = actions && actions.some((action) => action.type === OperationTypeCrud.save)
-    }
-
+    const result = cursorChanges && !Object.keys(cursorChanges).includes('_associate') && Object.values(cursorChanges).length
     return result
 }


### PR DESCRIPTION
We should decompose components as much as possible to avoid situations where our `<TableWidget />`  (or any other widget/component, for that matter) will become overgrow with code and functionality.

This PR is concentrated on extracting row operations floating menu into separate component, and preparing our `<TableWidget />` for unit tests (e.g. remove excessive dependencies from interface)

* `<RowOperations />` now handles floating menu.
  * Instead of a single div outside of table, with position and handler controlled via refs, operations are now displayed in last column, so we could contol visibility with a simple css-selector.
  * This should cover the troubles described in #87 when row menu button becomes stuck on single row or rowMeta not fetching causing wrong operations to show
  * `<TableWidget />` no longer depends on Ant Design components `Menu`, `Dropdown`, `Icon` and `Skeleton`, which makes it easier to extract UI part from that component
  * `<TableWidget />` code is much smaller and easier to understand without row menu logic
  * Button design conflicted with row higlight due to round form and white background, now it looks like native action. Additionally, horizontal `ellipsis` icon was replaced with vertical `more` icon to save a bit of space as we using it for tables.
* `<TableRow />` is a kit-agnostic row wrapper that handles our `row operations` feature (i.e. makes additional column and show/hide `<RowOperations />` when necessary) and common row handlers
* Table messages now internationalised
* `<TableWidget />` no longer connects to `router` (handled in epic instead), `bcName` (now directly uses `props.meta.bcName`), `pendingDataItem` (no longer in use), `onDrillDown` (no longer in use) and row menu props `onOperationClick`, `onSelectRow`, `metaInProgress`, they will be removed in 2.0.0
