### PR TITLE
Required fields validation errors

### DIFF
--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -2,7 +2,7 @@
     "translation": {
         "Apply": "Применить",
         "Clear": "Сбросить",
-        "Required fields are missing": "Незаполнены обязательные поля",
+        "Required fields are missing": "Не заполнены обязательные поля",
         "There are pending changes. Please save them or cancel.": "Остались несохраненные данные. Сохраните или отмените изменения.",
         "Cancel changes": "Отменить изменения"
     }

--- a/src/middlewares/requiredFieldsMiddleware.ts
+++ b/src/middlewares/requiredFieldsMiddleware.ts
@@ -89,7 +89,7 @@ function getRequiredFieldsMissing(record: DataItem, pendingChanges: PendingDataI
 
         const value = record && record[field.key] as string
         const pendingValue = pendingChanges && pendingChanges[field.key]
-        const effectiveValue = pendingChanges !== undefined ? pendingValue as string: value
+        const effectiveValue = pendingValue !== undefined ? pendingValue as string: value
         let falsyValue = false
         if ([undefined, null, ''].includes(effectiveValue)) {
             falsyValue = true

--- a/src/reducers/view.ts
+++ b/src/reducers/view.ts
@@ -159,7 +159,6 @@ export function view(state = initialState, action: AnyAction, store: Store) {
                         [cursor]: newPendingDataChanges
                     }
                 },
-                pendingValidationFails: initialState.pendingValidationFails,
                 rowMeta: {
                     ...state.rowMeta,
                     [bcName]: {


### PR DESCRIPTION
* forceActive fields should not drop all existing validation errors.
* requiredFieldsMiddleware incorrectly checked for effective value which could lead to non-empty fields highlighted as empty.
* Russian translation "Required fields are missing" message fix.