### PR TITLE
Version update 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Version 1.1.2
+
+## Fixes
+
+* Page crash after view change due to missing `Set` polyfill for IE11 (#12).
+* forceActive fields should not drop all existing validation errors.
+* requiredFieldsMiddleware incorrectly checked for effective value which could lead to non-empty fields highlighted as empty.
+* Russian translation "Required fields are missing" message fix.
+* Webpack config incorrectly referred `LICENSE.MD` instead of `LICENSE`
+* Non-working readme links on NPM 
+
 # Version 1.1.1
 
 ## Fixes

--- a/README.md
+++ b/README.md
@@ -68,10 +68,12 @@ The documentation is divided into several sections:
 * [Features](./docs/features.md)
 * [API Reference](./docs/api-reference.md)
 
+You could also check our [changelog section](https://github.com/tesler-platform/tesler-ui/blob/master/CHANGELOG.md).
+
 # Reporting an error
 
 In case you've encountered a problem, please open an issue with reproducible example and detailed description.  
-If you are also willing to provide a fix, please check our [contributing guide](./CONTRIBUTING.md)!
+If you are also willing to provide a fix, please check our [contributing guide](https://github.com/tesler-platform/tesler-ui/blob/master/CONTRIBUTING.md)!
 
 # Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tesler-ui/core",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "tesler-ui-core.js",
   "homepage": "https://tesler.io/",
   "types": "index.d.ts",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -151,7 +151,7 @@ module.exports = (env, options) => {
             new CopyWebpackPlugin([
                 { from: 'package.json' },
                 { from: 'README.MD' },
-                { from: 'LICENSE.MD' },
+                { from: 'LICENSE' },
                 { from: 'CHANGELOG.MD' },
                 { from: 'CONTRIBUTING.MD' }
             ])


### PR DESCRIPTION
* Webpack config incorrectly referred `LICENSE.MD` instead of `LICENSE`
* Non-working readme links on NPM 