### PR TITLE
Fix: List hierarchy loaded only first dept level data.

### DIFF
--- a/src/components/HierarchyTable/HierarchyTable.tsx
+++ b/src/components/HierarchyTable/HierarchyTable.tsx
@@ -225,7 +225,7 @@ export const HierarchyTable: FunctionComponent<HierarchyTableProps> = (props) =>
             dataSource={props.data}
             expandedRowRender={hasNested ? nested : undefined}
             expandIconAsCell={false}
-            expandIconColumnIndex={1}
+            expandIconColumnIndex={(rowSelection) ? 1 : 0}
             loading={props.loading}
         />
         {props.showPagination && <Pagination bcName={bcName} mode={PaginationMode.page} />}

--- a/src/epics/data.ts
+++ b/src/epics/data.ts
@@ -854,9 +854,7 @@ function requestBcChildren(bcName: string) {
             array[nextWidget.bcName].push(nextWidget.name)
             return array
         }, {} as ObjectMap<string[]>)
-    if (!state.view.popupData.bcName) {
-        return childrenBcMap
-    }
+
     // Если виджет поддерживает иерархию, то поискать дочерний в ней
     // TODO: сделать описание, разбить на хэлперы?
     const hierarchyWidget = state.view.widgets.find(item => {


### PR DESCRIPTION
Multiple BC hierarchy on list type widget loaded only first depth level data.

\+ fix incorrect expand icon position on list type widget