### PR TITLE
Fix an infinite loop when a business error is received during a change in a force-active field

### DIFF
--- a/src/epics/view.ts
+++ b/src/epics/view.ts
@@ -90,6 +90,7 @@ const getRowMetaByForceActive: Epic = (action$, store) => action$.ofType(types.c
         .filter((field) => field.forceActive && (pendingChanges[field.key] !== undefined))
         .some((field) => {
             const result = pendingChanges[field.key] !== handledForceActive[field.key]
+                && pendingChanges[field.key] !== currentRecordData[field.key]
             if (result) {
                 changedFiledKey = field.key
             }


### PR DESCRIPTION
See #35 