### PR TITLE
Add release workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,4 @@
+template: |
+  ## Changelog
+
+  $CHANGES

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+on:
+  push:
+    branches:
+      - master
+
+name: Build
+
+jobs:
+  assets:
+    name: Create NPM Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+          always-auth: true
+      - name: install
+        run: yarn install
+      - name: unit tests
+        run: yarn test
+      - name: linter
+        run: yarn lint
+      - name: build
+        run: yarn build
+      - name: navigate dist
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
+          cd dist
+          yarn publish --access public
+          cd ..
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  src:
+    needs: assets
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Pipeline
 
 on: pull_request
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Tesler UI
+# Tesler UI &middot; ![Build status](https://github.com/tesler-platform/tesler-ui/workflows/Build/badge.svg)
 
 Tesler UI is an open source library that supplies user interaction support for Tesler framework in form of React components, Redux reducers and redux-observable epics for handling asynchronous actions.
 More specifically that includes:

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -150,10 +150,10 @@ module.exports = (env, options) => {
             // new CleanWebpackPlugin(),
             new CopyWebpackPlugin([
                 { from: 'package.json' },
-                { from: 'README.MD' },
+                { from: 'README.md' },
                 { from: 'LICENSE' },
-                { from: 'CHANGELOG.MD' },
-                { from: 'CONTRIBUTING.MD' }
+                { from: 'CHANGELOG.md' },
+                { from: 'CONTRIBUTING.md' }
             ])
         ]
     }


### PR DESCRIPTION
Push to master branch now initiates publishing of [NPM package](https://www.npmjs.com/package/@tesler-ui/core) and prepares new [GitHub Release draft](https://github.com/tesler-platform/tesler-ui/releases) with list of new commits.

GitHub release is handled via [release-drafter/release-drafter](https://github.com/release-drafter/release-drafter).

`CI` workflow renamed to `Pipeline`.

Add badge in readme file thats shows `Build` workflow status.

`README.md`, `CONTRIBUTING.md` and `CHANGELOG.md` were incorrectly referenced with uppercase extensions and as a result were missing if build was performed from *nix systems.

