### PR TITLE
Feat/fix required fields

### DIFF
--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -92,8 +92,8 @@ export function configureStore<ClientState, ClientActions extends Action<any>>(
         }
     })
     const middlewares: Middleware[] = [
-        createRequiredFieldsMiddleware(),
-        createAutoSaveMiddleware()
+        createAutoSaveMiddleware(),
+        createRequiredFieldsMiddleware()
     ]
     if (useEpics) {
         const epics = combineEpics(coreEpics, customEpics)

--- a/src/interfaces/widget.ts
+++ b/src/interfaces/widget.ts
@@ -133,8 +133,15 @@ export type WidgetFormField = Extract<WidgetField, WidgetFormFieldBase>
 
 export type WidgetListField = Extract<WidgetField, WidgetListFieldBase>
 
+/* description for a block structure containing fields on a form */
+export interface WidgetBlock {
+    fields: object[],
+    blockId: string,
+    name: string
+}
+
 /**
- * @param readOnly All widget fields are not editable 
+ * @param readOnly All widget fields are not editable
  */
 export interface WidgetOptions {
     layout?: {

--- a/src/interfaces/widget.ts
+++ b/src/interfaces/widget.ts
@@ -194,7 +194,7 @@ export interface WidgetShowCondition {
 
 /**
  * Description of the list of fields of block type.
- * Deprecated interface
+ * @deprecated
  * Used to create a block grouping of fields
  *
  * @param blockId Block ID.

--- a/src/interfaces/widget.ts
+++ b/src/interfaces/widget.ts
@@ -133,13 +133,6 @@ export type WidgetFormField = Extract<WidgetField, WidgetFormFieldBase>
 
 export type WidgetListField = Extract<WidgetField, WidgetListFieldBase>
 
-/* description for a block structure containing fields on a form */
-export interface WidgetBlock {
-    fields: object[],
-    blockId: string,
-    name: string
-}
-
 /**
  * @param readOnly All widget fields are not editable
  */
@@ -199,6 +192,15 @@ export interface WidgetShowCondition {
     }
 }
 
+/**
+ * Description of the list of fields of block type.
+ * Deprecated interface
+ * Used to create a block grouping of fields
+ *
+ * @param blockId Block ID.
+ * @param name The name of the block.
+ * @param Fields an array of fields of type T.
+ */
 export interface WidgetFieldBlock<T> {
     blockId: number,
     name: string,

--- a/src/middlewares/requiredFieldsMiddleware.ts
+++ b/src/middlewares/requiredFieldsMiddleware.ts
@@ -11,7 +11,7 @@ import {openButtonWarningNotification} from '../utils/notifications'
 import i18n from 'i18next'
 import {PendingDataItem, DataItem} from '../interfaces/data'
 import {RowMetaField} from '../interfaces/rowMeta'
-import {WidgetField, WidgetBlock, WidgetTypes} from '../interfaces/widget'
+import {WidgetField, WidgetFieldBlock} from '../interfaces/widget'
 
 const requiredFields = ({ getState, dispatch }: MiddlewareAPI<Dispatch<AnyAction>, CoreStore>) => (next: Dispatch) =>
 (action: AnyAction) => {
@@ -38,12 +38,20 @@ const requiredFields = ({ getState, dispatch }: MiddlewareAPI<Dispatch<AnyAction
             state.view.widgets
             .filter(item => item.bcName === widget.bcName)
             .forEach(item => {
-                let itemFieldsCalc: object[] = []
-                if (item.type === WidgetTypes.List) {
-                    itemFieldsCalc = item.fields
-                }
-                if (item.type === WidgetTypes.Form) {
-                    item.fields.forEach((block: WidgetBlock) => {block.fields.forEach((field: []) => itemFieldsCalc.push(field))})
+                const itemFieldsCalc: object[] = item.fields
+                if (item.fields) {
+                    item.fields.forEach((block: object | WidgetFieldBlock<object>) => {
+                        /**
+                         * block check
+                         * @param itemObject
+                         */
+                        function isWidgetFieldBlock(itemObject: any): itemObject is WidgetFieldBlock<object> {
+                            return !!itemObject && ('fields' in itemObject)
+                        }
+                        if (isWidgetFieldBlock(block)) {
+                            block.fields.forEach((field: []) => itemFieldsCalc.push(field))
+                        }
+                    })
                 }
                 itemFieldsCalc.forEach((widgetField: WidgetField) => {
                     const matchingRowMeta = rowMeta.fields.find(rowMetaField => rowMetaField.key === widgetField.key)

--- a/src/middlewares/requiredFieldsMiddleware.ts
+++ b/src/middlewares/requiredFieldsMiddleware.ts
@@ -11,7 +11,7 @@ import {openButtonWarningNotification} from '../utils/notifications'
 import i18n from 'i18next'
 import {PendingDataItem, DataItem} from '../interfaces/data'
 import {RowMetaField} from '../interfaces/rowMeta'
-import {WidgetField, WidgetFieldBlock} from '../interfaces/widget'
+import {WidgetField, WidgetFieldBlock, isWidgetFieldBlock} from '../interfaces/widget'
 
 const requiredFields = ({ getState, dispatch }: MiddlewareAPI<Dispatch<AnyAction>, CoreStore>) => (next: Dispatch) =>
 (action: AnyAction) => {
@@ -41,13 +41,6 @@ const requiredFields = ({ getState, dispatch }: MiddlewareAPI<Dispatch<AnyAction
                 const itemFieldsCalc: object[] = item.fields
                 if (item.fields) {
                     item.fields.forEach((block: object | WidgetFieldBlock<object>) => {
-                        /**
-                         * block check
-                         * @param itemObject
-                         */
-                        function isWidgetFieldBlock(itemObject: any): itemObject is WidgetFieldBlock<object> {
-                            return !!itemObject && ('fields' in itemObject)
-                        }
                         if (isWidgetFieldBlock(block)) {
                             block.fields.forEach((field: []) => itemFieldsCalc.push(field))
                         }


### PR DESCRIPTION
middleware reordering due to the incorrect operation of the field required check during the transition between the lines of the list widget: first, autosave worked, and then the required check.
check list or forms when forming a list of required fields
JSDoc for WidgetFieldBlock block structure
In requiredFieldsMiddleware the selectTableCellInit action has been added for autofocusing on a required empty field (it works only for saving / autosaving on a list widget, no errors were found on other widgets)