### PR TITLE
Added hierarchy for PickListPopup

### DIFF
--- a/src/components/FullHierarchyTable/FullHierarchyTable.tsx
+++ b/src/components/FullHierarchyTable/FullHierarchyTable.tsx
@@ -6,7 +6,7 @@ import {Store} from '../../interfaces/store'
 import {Dispatch} from 'redux'
 import {connect} from 'react-redux'
 import {Icon, Table} from 'antd'
-import {ColumnProps, TableRowSelection} from 'antd/lib/table'
+import {ColumnProps, TableRowSelection, TableEventListeners} from 'antd/lib/table'
 import {DataItem, MultivalueSingleValue, PendingDataItem} from '../../interfaces/data'
 import {FieldType} from '../../interfaces/view'
 import MultivalueHover from '../ui/Multivalue/MultivalueHover'
@@ -19,7 +19,8 @@ interface FullHierarchyTableOwnProps {
     assocValueKey?: string,
     depth?: number,
     parentId?: string,
-    selectable?: boolean
+    selectable?: boolean,
+    onRow?: (record: DataItem, index: number) => TableEventListeners
 }
 
 interface FullHierarchyTableProps {
@@ -61,6 +62,7 @@ const FullHierarchyTable: React.FunctionComponent<FullHierarchyTableAllProps> = 
     const hierarchyGroupDeselection = props.meta.options && props.meta.options.hierarchyGroupDeselection
     const hierarchyRadioAll = props.meta.options && props.meta.options.hierarchyRadioAll
     const hierarchyRootRadio = props.meta.options && props.meta.options.hierarchyRadio
+    const hierarchyDisableRoot = props.meta.options && props.meta.options.hierarchyDisableRoot
 
     const selectedRecords = useAssocRecords(props.data, props.pendingChanges)
     const [userOpenedRecords, setUserOpenedRecords] = React.useState([])
@@ -150,7 +152,8 @@ const FullHierarchyTable: React.FunctionComponent<FullHierarchyTableAllProps> = 
             assocValueKey={props.assocValueKey}
             depth={depthLevel + 1}
             parentId={record.id}
-            selectable
+            selectable={props.selectable}
+            onRow={props.onRow}
         />
     }
 
@@ -212,8 +215,9 @@ const FullHierarchyTable: React.FunctionComponent<FullHierarchyTableAllProps> = 
             dataSource={tableRecords}
             expandedRowRender={nestedHierarchy}
             expandIconAsCell={false}
-            expandIconColumnIndex={1}
+            expandIconColumnIndex={props.onRow ? 0 : 1}
             loading={props.loading}
+            onRow={!(hierarchyDisableRoot && depthLevel === 1) && props.onRow}
         />
     </div>
 }

--- a/src/components/HierarchyTable/HierarchyTable.tsx
+++ b/src/components/HierarchyTable/HierarchyTable.tsx
@@ -10,7 +10,7 @@ import {buildBcUrl} from '../../utils/strings'
 import {WidgetTableMeta, WidgetListField } from '../../interfaces/widget'
 import {DataItem, MultivalueSingleValue, PendingDataItem } from '../../interfaces/data'
 import {RowMetaField } from '../../interfaces/rowMeta'
-import {ColumnProps, TableRowSelection } from 'antd/lib/table'
+import {ColumnProps, TableRowSelection, TableEventListeners} from 'antd/lib/table'
 import {Route } from '../../interfaces/router'
 import {FieldType } from '../../interfaces/view'
 import styles from './HierarchyTable.less'
@@ -24,7 +24,8 @@ interface HierarchyTableOwnProps {
     assocValueKey?: string,
     nestedByBc?: string,
     parentBcName?: string
-    showPagination?: boolean
+    showPagination?: boolean,
+    onRow?: (record: DataItem, index: number) => TableEventListeners
 }
 
 export interface HierarchyTableProps extends HierarchyTableOwnProps {
@@ -67,6 +68,7 @@ export const HierarchyTable: FunctionComponent<HierarchyTableProps> = (props) =>
     const hierarchyRadio = props.meta.options && props.meta.options.hierarchyRadio
     const hierarchyRadioAll = props.meta.options && props.meta.options.hierarchyRadioAll
     const hierarchyLevels = props.meta.options && props.meta.options.hierarchy
+    const hierarchyDisableRoot = props.meta.options && props.meta.options.hierarchyDisableRoot
 
     // TODO: Переделать в более понятный вид
     const indentLevel = props.nestedByBc
@@ -165,6 +167,7 @@ export const HierarchyTable: FunctionComponent<HierarchyTableProps> = (props) =>
             assocValueKey={nestedHierarchyDescriptor.assocValueKey}
             nestedByBc={nestedBcName}
             onDrillDown={null}
+            onRow={props.onRow}
         />
     }
 
@@ -227,6 +230,7 @@ export const HierarchyTable: FunctionComponent<HierarchyTableProps> = (props) =>
             expandIconAsCell={false}
             expandIconColumnIndex={(rowSelection) ? 1 : 0}
             loading={props.loading}
+            onRow={!(hierarchyDisableRoot && indentLevel === 0) && props.onRow}
         />
         {props.showPagination && <Pagination bcName={bcName} mode={PaginationMode.page} />}
     </div>

--- a/src/components/SameBcHierarchyTable/SameBcHierarchyTable.tsx
+++ b/src/components/SameBcHierarchyTable/SameBcHierarchyTable.tsx
@@ -8,7 +8,7 @@ import Field from '../../components/Field/Field'
 import MultivalueHover from '../../components/ui/Multivalue/MultivalueHover'
 import {WidgetTableMeta, WidgetListField} from '../../interfaces/widget'
 import {DataItem, MultivalueSingleValue, PendingDataItem } from '../../interfaces/data'
-import {ColumnProps, TableRowSelection } from 'antd/lib/table'
+import {ColumnProps, TableRowSelection, TableEventListeners} from 'antd/lib/table'
 import {Route } from '../../interfaces/router'
 import {FieldType } from '../../interfaces/view'
 import styles from './SameBcHierarchyTable.less'
@@ -20,6 +20,7 @@ interface SameBcHierarchyTableOwnProps {
     assocValueKey?: string,
     depth?: number,
     selectable?: boolean,
+    onRow?: (record: DataItem, index: number) => TableEventListeners
 }
 
 export interface SameBcHierarchyTableProps extends SameBcHierarchyTableOwnProps {
@@ -60,6 +61,7 @@ export const SameBcHierarchyTable: FunctionComponent<SameBcHierarchyTableProps> 
 
     const hierarchyGroupSelection = props.meta.options && props.meta.options.hierarchyGroupSelection
     const hierarchyRadioAll = props.meta.options && props.meta.options.hierarchyRadioAll
+    const hierarchyDisableRoot = props.meta.options && props.meta.options.hierarchyDisableRoot
 
     const depthLevel = props.depth || 1
     const indentLevel = depthLevel - 1
@@ -121,6 +123,7 @@ export const SameBcHierarchyTable: FunctionComponent<SameBcHierarchyTableProps> 
             assocValueKey={props.assocValueKey}
             onDrillDown={null}
             depth={depthLevel + 1}
+            onRow={props.onRow}
         />
     }
 
@@ -181,8 +184,9 @@ export const SameBcHierarchyTable: FunctionComponent<SameBcHierarchyTableProps> 
             dataSource={props.data}
             expandedRowRender={hasNested ? nested : undefined}
             expandIconAsCell={false}
-            expandIconColumnIndex={1}
+            expandIconColumnIndex={props.onRow ? 0 : 1}
             loading={props.loading}
+            onRow={!(hierarchyDisableRoot && depthLevel === 1) && props.onRow}
         />
     </div>
 }

--- a/src/components/widgets/PickListPopup/PickListPopup.tsx
+++ b/src/components/widgets/PickListPopup/PickListPopup.tsx
@@ -10,6 +10,9 @@ import {Table, Skeleton} from 'antd'
 import {ColumnProps} from 'antd/es/table'
 import {DataItem, PickMap} from '../../../interfaces/data'
 import {ChangeDataItemPayload} from '../../Field/Field'
+import SameBcHierarchyTable from '../../SameBcHierarchyTable/SameBcHierarchyTable'
+import HierarchyTable from '../../../components/HierarchyTable/HierarchyTable'
+import FullHierarchyTable from '../../FullHierarchyTable/FullHierarchyTable'
 
 export interface PickListPopupActions {
     onChange: (payload: ChangeDataItemPayload) => void,
@@ -69,7 +72,24 @@ export const PickListPopup: FunctionComponent<PickListPopupProps & PickListPopup
         <div>
             <h2 className={styles.title}>{props.widget.title}</h2>
             {(props.bcLoading)
-                ? <Skeleton loading paragraph={{rows: 5}} />
+            ? <Skeleton loading paragraph={{rows: 5}} />
+            : (props.widget.options
+                && (props.widget.options.hierarchy || props.widget.options.hierarchySameBc || props.widget.options.hierarchyFull)
+            )
+                ? props.widget.options.hierarchyFull
+                    ? <FullHierarchyTable
+                        meta={props.widget}
+                        onRow={onRow}
+                    />
+                    : (props.widget.options.hierarchySameBc)
+                        ? <SameBcHierarchyTable
+                            meta={props.widget}
+                            onRow={onRow}
+                        />
+                        : <HierarchyTable
+                            meta={props.widget}
+                            onRow={onRow}
+                        />
                 : <div>
                     <Table
                         className={styles.table}

--- a/src/interfaces/widget.ts
+++ b/src/interfaces/widget.ts
@@ -153,6 +153,7 @@ export interface WidgetOptions {
     hierarchyTraverse?: boolean,
     hierarchyRadio?: boolean,
     hierarchyRadioAll?: boolean,
+    hierarchyDisableRoot?: boolean,
     actionGroups?: WidgetOperations,
     readOnly?: boolean,
     /**


### PR DESCRIPTION
Added hierarchy for PickListPopup

Three types of hierarchy are available: FullHierarchyTable, SameBcHierarchyTable, HierarchyTable

Added new parameter to widget options:
```
hierarchyDisableRoot: boolean
```
This option disables the ability to select a row from the root level.