### PR TITLE
Table widget should show drilldown button when cell is in edit mode (#64)

### DIFF
--- a/src/components/widgets/TableWidget/TableWidget.tsx
+++ b/src/components/widgets/TableWidget/TableWidget.tsx
@@ -295,7 +295,7 @@ export const TableWidget: FunctionComponent<TableWidgetProps> = (props) => {
                 </div>
             },
             onCell: (record, rowIndex) => {
-                return (!props.allowEdit || item.drillDown)
+                return (!props.allowEdit)
                     ? null
                     : {
                         onDoubleClick: (event) => {


### PR DESCRIPTION
* `PickListField`, `InlinePickList` and `Input` field types now use `InteractiveInput` component to show drilldown button on Table widgets
* `onDrillDown` handler moved to common props due to drilldown flag been equally available for all field types (at least by interfae)