### PR TITLE
New record creation should be cancelable from Table widget (#66)

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -311,14 +311,18 @@ export class ActionPayloadTypes {
     /**
      * TODO
      * 
-     * @param bcName
      * @param postInvoke
      * @param cursor
+     * @param widgetName What widget initiated original operation, TODO: mandatory in 2.0.0
+     * 
+     * @deprecated TODO: Prefer widgetName instead (2.0.0)
+     * @param bcName
      */
     processPostInvoke: {
         bcName: string,
         postInvoke: OperationPostInvokeAny,
         cursor?: string
+        widgetName?: string
     } = z
 
     /**

--- a/src/epics/data.ts
+++ b/src/epics/data.ts
@@ -299,7 +299,7 @@ const bcNewDataEpic: Epic = (action$, store) => action$.ofType(types.sendOperati
             Observable.of($do.bcNewDataSuccess({ bcName, dataItem, bcUrl })),
             Observable.of($do.bcFetchRowMetaSuccess({ bcName, bcUrl: `${bcUrl}/${cursor}`, rowMeta, cursor})),
             postInvoke
-                ? Observable.of($do.processPostInvoke({ bcName, postInvoke, cursor}))
+                ? Observable.of($do.processPostInvoke({ bcName, postInvoke, cursor, widgetName: action.payload.widgetName }))
                 : Observable.empty<never>()
         )
     })


### PR DESCRIPTION
See #66 

* `postDelete` has been trying to redirect user from record creation for back to the table view by checking and modifying the route, which is not correct if user was not redirected from the table in the first place. 
*  `processPostInvoke` action now accepts `widgetName` as payload and in the future (2.0.0) will require it mandatory. 