### PR TITLE
Support for templates in field names (${name}) for Form and Table widgets

### DIFF
--- a/src/components/ColumnTitle/ColumnTitle.tsx
+++ b/src/components/ColumnTitle/ColumnTitle.tsx
@@ -4,6 +4,7 @@ import {WidgetListField} from '../../interfaces/widget'
 import ColumnFilter from './ColumnFilter'
 import ColumnSort from './ColumnSort'
 import styles from './ColumnTitle.less'
+import TemplatedTitle from '../TemplatedTitle/TemplatedTitle'
 
 export interface ColumnTitle {
     widgetName: string,
@@ -15,8 +16,12 @@ export const ColumnTitle: FunctionComponent<ColumnTitle> = (props) => {
     if (!props.widgetMeta && !props.rowMeta) {
         return null
     }
+    const title = <TemplatedTitle
+        widgetName={props.widgetName}
+        title={props.widgetMeta.title}
+    />
     if (!props.rowMeta) {
-        return <div>{props.widgetMeta.title}</div>
+        return <div>{title}</div>
     }
 
     const filterable = props.rowMeta.filterable
@@ -32,7 +37,7 @@ export const ColumnTitle: FunctionComponent<ColumnTitle> = (props) => {
             rowMeta={props.rowMeta}
         />
     return <div className={styles.container}>
-        {props.widgetMeta.title}
+        {title}
         {filter}
         {sort}
     </div>

--- a/src/components/TemplatedTitle/TemplatedTitle.tsx
+++ b/src/components/TemplatedTitle/TemplatedTitle.tsx
@@ -1,0 +1,35 @@
+import React, {FunctionComponent} from 'react'
+import {connect} from 'react-redux'
+import {Store} from '../../interfaces/store'
+import {getFieldTitle} from '../../utils/strings'
+
+interface TemplatedTitleOwnProps {
+    title: string,
+    widgetName: string,
+    container?: React.ComponentType<any>
+}
+
+interface TemplatedTitleProps extends TemplatedTitleOwnProps {
+    templatedTitle: string
+}
+
+export const TemplatedTitle: FunctionComponent<TemplatedTitleProps> = (props) => {
+    if (!props.title) {
+        return null
+    }
+    const wrapper = props.container && <props.container title={props.templatedTitle}/>
+    return wrapper || <> {props.templatedTitle} </>
+}
+
+function mapStateToProps(store: Store, ownProps: TemplatedTitleOwnProps) {
+    const widget = store.view.widgets.find(item => item.name === ownProps.widgetName)
+    const bcName = widget && widget.bcName
+    const bc = store.screen.bo.bc[bcName]
+    const cursor = bc && bc.cursor
+    const bcData = store.data[bcName]
+    const dataItem = bcData && bcData.find(item => item.id === cursor)
+    return {
+        templatedTitle: getFieldTitle(ownProps.title, dataItem)
+    }
+}
+export default connect(mapStateToProps)(TemplatedTitle)

--- a/src/components/widgets/FormWidget/FormWidget.tsx
+++ b/src/components/widgets/FormWidget/FormWidget.tsx
@@ -10,6 +10,7 @@ import {useFlatFormFields} from '../../../hooks/useFlatFormFields'
 import styles from './FormWidget.less'
 import cn from 'classnames'
 import {FieldType} from '../../../interfaces/view'
+import TemplatedTitle from '../../TemplatedTitle/TemplatedTitle'
 
 interface FormWidgetOwnProps {
     meta: WidgetFormMeta,
@@ -51,12 +52,17 @@ export const FormWidget: FunctionComponent<FormWidgetProps> = (props) => {
                         const field = flattenWidgetFields.find(item => item.key === col.fieldKey)
                         const error = (props.missingFields && props.missingFields[field.key])
                             || props.metaErrors && props.metaErrors[field.key]
-                        const fieldLabel = field.type === 'checkbox' ? null : field.label
                         return  <Col key={colIndex} span={col.span} className={cn(
                             {[styles.colWrapper]: row.cols.length > 1 || col.span !== 24}
                         )}>
                             <Form.Item
-                                label={fieldLabel}
+                                label={field.type === 'checkbox'
+                                    ? null
+                                    : <TemplatedTitle
+                                        widgetName={props.meta.name}
+                                        title={field.label}
+                                    />
+                                }
                                 validateStatus={error ? 'error' : undefined}
                                 help={error}
                             >


### PR DESCRIPTION
See #94 
Tokens are replaced in the template line with the values ​​of the object fields.
If the value is like a date, then convert it to the format 'DD.MM.YYYY' 

Example:
const item = { color1: 'Green', color2: 'Blue' }
const templatedString = 'Color is ${color1} ${color2:Purple} ${color3:Purple}'
format(templateString, item) // => 'Green Blue Purple'