### PR TITLE
Reset cursor of treeData table on page change

### DIFF
--- a/src/components/HierarchyTable/HierarchyTable.tsx
+++ b/src/components/HierarchyTable/HierarchyTable.tsx
@@ -145,7 +145,7 @@ export const HierarchyTable: FunctionComponent<HierarchyTableProps> = (props) =>
             return props.data && props.data.map((item) => {
                 return {
                     ...item,
-                    noChildren: (currentCursor && noChildRecords.includes(item.id))
+                    noChildren: noChildRecords.includes(item.id)
                 }
             })
         },
@@ -174,6 +174,10 @@ export const HierarchyTable: FunctionComponent<HierarchyTableProps> = (props) =>
             setUserClosedRecords([ ...userClosedRecords, dataItem.id ])
         }
     }
+
+    const resetCursor = React.useCallback(() => {
+        setCurrentCursor(null)
+    }, [])
 
     // Вложенный уровень иерархии рисуется новой таблицей
     const nested = (record: DataItem, index: number, indent: number, expanded: boolean) => {
@@ -254,7 +258,8 @@ export const HierarchyTable: FunctionComponent<HierarchyTableProps> = (props) =>
             loading={props.loading}
             onRow={!(hierarchyDisableRoot && indentLevel === 0) && props.onRow}
         />
-        {props.showPagination && <Pagination bcName={bcName} mode={PaginationMode.page} />}
+        {props.showPagination &&
+        <Pagination bcName={bcName} mode={PaginationMode.page} onChangePage={resetCursor}/>}
     </div>
 }
 

--- a/src/components/ui/Pagination/Pagination.tsx
+++ b/src/components/ui/Pagination/Pagination.tsx
@@ -10,6 +10,7 @@ import {$do} from '../../../actions/actions'
 interface PaginationOwnProps {
     bcName: string
     mode: PaginationMode,
+    onChangePage?: () => void,
 }
 
 interface PaginationStateProps {
@@ -40,6 +41,9 @@ const Pagination: React.FunctionComponent<PaginationAllProps> = (props) => {
     const onPrevPage = React.useCallback(
         () => {
             props.changePage(props.bcName, props.page - 1)
+            if (props.onChangePage) {
+                props.onChangePage()
+            }
         },
         [props.bcName, props.page, props.changePage]
     )
@@ -47,6 +51,9 @@ const Pagination: React.FunctionComponent<PaginationAllProps> = (props) => {
     const onNextPage = React.useCallback(
         () => {
             props.changePage(props.bcName, props.page + 1)
+            if (props.onChangePage) {
+                props.onChangePage()
+            }
         },
         [props.bcName, props.page, props.changePage]
     )


### PR DESCRIPTION
See #76 
It is necessary to reset the treeData table cursor when changing the page, because the cursor remains on the last open record of the previous page, and this will break the behavior of the table.