### PR TITLE
Added PostInvokeConfirm operation

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -10,7 +10,13 @@ import {DataItem, MultivalueSingleValue, PendingDataItem, PickMap} from '../inte
 import {Store as CoreStore} from '../interfaces/store'
 import {RowMeta} from '../interfaces/rowMeta'
 import {ObjectMap, AppNotificationType} from '../interfaces/objectMap'
-import {OperationPostInvokeAny, OperationTypeCrud, AssociatedItem, OperationErrorEntity} from '../interfaces/operation'
+import {
+    OperationPostInvokeAny,
+    OperationTypeCrud,
+    AssociatedItem,
+    OperationErrorEntity,
+    OperationPreInvoke
+} from '../interfaces/operation'
 import {BcFilter, BcSorter} from '../interfaces/filters'
 
 const z = null as any
@@ -297,18 +303,20 @@ export class ActionPayloadTypes {
     } = z
 
     /**
-     * TODO
+     * Perform CustomAction 
      * 
-     * @param bcName
-     * @param operationType
-     * @param widgetName
-     * @param onSuccessAction
+     * @param bcName The business component to fetch data for
+     * @param operationType Type of operation to be performed
+     * @param widgetName What widget requires data
+     * @param onSuccessAction Any other action
+     * @param confirmOperation params for confirm modal
      */
     sendOperation: {
         bcName: string,
         operationType: OperationTypeCrud | string,
         widgetName: string,
         onSuccessAction?: AnyAction,
+        confirmOperation?: OperationPreInvoke
     } = z
 
     /**
@@ -352,6 +360,21 @@ export class ActionPayloadTypes {
         postInvoke: OperationPostInvokeAny,
         cursor?: string
         widgetName?: string
+    } = z
+
+    /**
+     * Operation to perform preInvoke actions
+     * 
+     * @param bcName The business component to fetch data for
+     * @param operationType Type of operation to be performed
+     * @param widgetName What widget requires data
+     * @param preInvoke the action that will be performed before the main operation
+     */
+    processPreInvoke: {
+        bcName: string,
+        operationType: string
+        widgetName: string
+        preInvoke: OperationPreInvoke
     } = z
 
     /**
@@ -580,6 +603,21 @@ export class ActionPayloadTypes {
         bcUrl: string,
         entityError?: OperationErrorEntity,
         viewError?: string
+    } = z
+
+    /**
+     * Save info about current operation for confirm modal
+     * 
+     * @param operation Current operation
+     * @param confirmOperation Text for confirm modal
+     */
+    operationConfirmation: {
+        operation: {
+            bcName: string,
+            operationType: OperationTypeCrud | string,
+            widgetName: string,
+        },
+        confirmOperation: OperationPreInvoke
     } = z
 
     /**
@@ -910,6 +948,11 @@ export class ActionPayloadTypes {
      * TODO
      */
     closeViewError: null = z
+
+    /**
+     * Close confirm modal window
+     */
+    closeConfirmModal: null = z
 
     /**
      * TODO

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1,6 +1,11 @@
 {
     "translation": {
         "Apply": "Apply",
-        "Clear": "Clear"
+        "Clear": "Clear",
+        "Cancel": "Cancel",
+        "Ok": "Ok",
+        "Are you sure?": "Are you sure?",
+        "Perform an additional action?": "Perform an additional action?",
+        "The operation is not supported": "The operation is not supported"
     }
 }

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -4,6 +4,11 @@
         "Clear": "Сбросить",
         "Required fields are missing": "Не заполнены обязательные поля",
         "There are pending changes. Please save them or cancel.": "Остались несохраненные данные. Сохраните или отмените изменения.",
-        "Cancel changes": "Отменить изменения"
+        "Cancel changes": "Отменить изменения",
+        "Cancel": "Отменить",
+        "Ok": "Ок",
+        "Are you sure?": "Вы уверены?",
+        "Perform an additional action?": "Выполнить дополнительное действие?",
+        "The operation is not supported": "Операция не поддерживается"
     }
 }

--- a/src/components/ModalInvoke/ModalInvoke.tsx
+++ b/src/components/ModalInvoke/ModalInvoke.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import {Dispatch} from 'redux'
+import {connect} from 'react-redux'
+import {Store} from '../../interfaces/store'
+import {Modal} from 'antd'
+import {$do} from '../../actions/actions'
+import {useTranslation} from 'react-i18next'
+import {OperationPreInvoke} from 'interfaces/operation'
+
+interface ModalInvokeProps {
+    bcName: string,
+    operationType: string,
+    widgetName: string,
+    confirmOperation: OperationPreInvoke
+    onOk: (bcName: string, operationType: string, widgetName: string, postInvokeConfirm: OperationPreInvoke) => void,
+    onCancel: () => void,
+}
+
+const ModalInvoke: React.FunctionComponent<ModalInvokeProps> = (props) => {
+    const {t} = useTranslation()
+    const modal = Modal.confirm({
+        title: props.confirmOperation && props.confirmOperation.message || t('Perform an additional action?'),
+        content: t('Are you sure?'),
+        okText: t('Ok'),
+        cancelText: t('Cancel')
+    })
+    modal.update({
+        onOk: () => {
+            props.onOk(
+                props.bcName,
+                props.operationType,
+                props.widgetName,
+                props.confirmOperation
+            )
+            modal.destroy()
+        },
+        onCancel: () => {
+            props.onCancel()
+        }
+    })
+    return null
+}
+
+function mapStateToProps(store: Store) {
+    const {operation, confirmOperation} = store.view.modalInvoke
+    return {
+        bcName: operation.bcName,
+        operationType: operation.operationType,
+        widgetName: operation.widgetName,
+        confirmOperation,
+    }
+}
+
+function mapDispatchToProps(dispatch: Dispatch) {
+    return {
+        onOk: (bcName: string, operationType: string, widgetName: string, confirmOperation?: OperationPreInvoke) => {
+            dispatch($do.sendOperation({ bcName, operationType, widgetName, confirmOperation}))
+            dispatch($do.closeConfirmModal(null))
+        },
+        onCancel: () => {
+            dispatch($do.closeConfirmModal(null))
+        }
+    }
+}
+
+const ConnectedModalInvoke = connect(mapStateToProps, mapDispatchToProps)(ModalInvoke)
+export default ConnectedModalInvoke

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -17,6 +17,7 @@ export {default as TemplatedTitle} from './TemplatedTitle/TemplatedTitle'
 export {default as View} from './View/View'
 export {default as Widget} from './Widget/Widget'
 export {default as Field} from './Field/Field'
+export {default as ModalInvoke} from './ModalInvoke/ModalInvoke'
 // Бизнес-виджеты
 export {default as FormWidget} from './widgets/FormWidget/FormWidget'
 export {default as TableWidget} from './widgets/TableWidget/TableWidget'

--- a/src/epics/screen.ts
+++ b/src/epics/screen.ts
@@ -7,7 +7,8 @@ import {
     OperationPostInvokeDrillDown,
     OperationPostInvokeShowMessage,
     OperationPostInvokeDownloadFile,
-    OperationPostInvokeDownloadFileByUrl
+    OperationPostInvokeDownloadFileByUrl,
+    OperationPreInvokeType
 } from '../interfaces/operation'
 import {ObjectMap} from '../interfaces/objectMap'
 import {historyObj} from '../reducers/router'
@@ -109,8 +110,27 @@ const downloadFileByUrl: Epic = (action$, store) => action$.ofType(types.downloa
     return Observable.empty()
 })
 
+const processPreInvoke: Epic = (action$, store) => action$.ofType(types.processPreInvoke)
+.mergeMap((action) => {
+    switch (action.payload.preInvoke.type) {
+        case OperationPreInvokeType.confirm:
+            const {bcName, operationType, widgetName, preInvoke} = action.payload
+            return Observable.of($do.operationConfirmation({
+                operation: {
+                    bcName,
+                    operationType,
+                    widgetName,
+                },
+                confirmOperation: preInvoke
+            }))
+        default:
+            return Observable.empty()
+    }
+})
+
 export const screenEpics = combineEpics(
     processPostInvoke,
     downloadFile,
-    downloadFileByUrl
+    downloadFileByUrl,
+    processPreInvoke
 )

--- a/src/interfaces/data.ts
+++ b/src/interfaces/data.ts
@@ -1,4 +1,4 @@
-import {OperationPostInvokeAny} from './operation'
+import {OperationPostInvokeAny, OperationPreInvoke} from './operation'
 import {DrillDownType} from './router'
 
 /**
@@ -57,7 +57,8 @@ export interface DepthDataState {
 export interface DataItemResponse {
     data: {
         record: DataItem,
-        postActions?: OperationPostInvokeAny[]
+        postActions?: OperationPostInvokeAny[],
+        preInvoke?: OperationPreInvoke
     }
 }
 

--- a/src/interfaces/operation.ts
+++ b/src/interfaces/operation.ts
@@ -47,6 +47,7 @@ export type OperationType = OperationTypeCrud | string
  * @param scope - ???
  * @param preInvoke - действие, которое надо произвести прежде чем начать выполнять операцию
  * @param autoSaveBefore Validate the record for empty "required" fields before API call
+ * @param confirmOperation Data for preInvoke confirm action
  */
 export interface Operation {
     text: string,
@@ -56,7 +57,8 @@ export interface Operation {
     icon?: string,
     showOnlyIcon: boolean,
     preInvoke?: OperationPreInvoke,
-    autoSaveBefore?: boolean
+    autoSaveBefore?: boolean,
+    confirmOperation?: OperationPreInvoke
 }
 
 /**

--- a/src/interfaces/view.ts
+++ b/src/interfaces/view.ts
@@ -2,6 +2,7 @@ import {WidgetMeta} from '../interfaces/widget'
 import {RowMeta} from '../interfaces/rowMeta'
 import {PendingDataItem, PickMap} from '../interfaces/data'
 import {SystemNotification} from './objectMap'
+import {OperationTypeCrud, OperationPreInvoke} from './operation'
 
 export interface ViewSelectedCell {
     widgetName: string,
@@ -34,7 +35,15 @@ export interface ViewState extends ViewMetaResponse {
     selectedCell?: ViewSelectedCell,
     systemNotifications?: SystemNotification[],
     error?: ApplicationError,
-    pendingValidationFails?: Record<string, string>
+    pendingValidationFails?: Record<string, string>,
+    modalInvoke?: {
+        operation: {
+            bcName: string,
+            operationType: OperationTypeCrud | string,
+            widgetName: string,
+        }
+        confirmOperation: OperationPreInvoke
+    },
 }
 
 export interface ViewMetaResponse {

--- a/src/reducers/view.ts
+++ b/src/reducers/view.ts
@@ -23,7 +23,8 @@ const initialState: ViewState  = {
     selectedCell: null,
     ignoreHistory: null,
     systemNotifications: [],
-    error: null
+    error: null,
+    modalInvoke: null
 }
 
 /**
@@ -386,6 +387,12 @@ export function view(state = initialState, action: AnyAction, store: Store) {
         }
         case types.showViewError: {
             return { ...state, error: action.payload.error }
+        }
+        case types.operationConfirmation: {
+            return { ...state, modalInvoke: action.payload}
+        }
+        case types.closeConfirmModal: {
+            return { ...state, modalInvoke: null }
         }
         case types.closeViewError:
             return { ...state, error: null }


### PR DESCRIPTION
Added the possibility of an additional request to the server after user confirmation.

After customAction is executed, the server response must contain the parameter:

```
preInvoke: {
    type: OperationPreInvokeType //must be of type 'confirm' 
    message: string  // message for user
}
```
After sending a customAction that will return this parameter, the user will have a modal window. If user confirm this action POST request will be sent to the server with parameter 
```
_confirm = confirmOperation.type
```
The server response may contain new Data parameters and postInvoke actions that will also be executed