### PR TITLE
Request data for widget BC ancestors (#113)

### DIFF
--- a/src/epics/data.ts
+++ b/src/epics/data.ts
@@ -25,36 +25,26 @@ const selectView: Epic = (action$, store) => action$.ofType(types.selectView)
     const state = store.getState()
     const bcToLoad: ObjectMap<WidgetMeta> = {}
     state.view.widgets
-        .filter(widget => {
-            if (!widget.bcName) {
-                return false
-            }
-
-            const parentBcName = state.screen.bo.bc[widget.bcName].parentName
-            const parentBc = parentBcName && state.screen.bo.bc[parentBcName]
-            // На загрузку попадают корневые бизнес-компоненты у которых нет родителя,
-            // и те у которых родитель уже с курсором и загружен
-            return !parentBcName || (parentBc.cursor && !parentBc.loading)
-        })
-        // Несколько виджетов могут ссылаться на одну бизнес-компоненту, поэтому фильтруем чтоб не было повторений
         .forEach(widget => {
-            if (!bcToLoad[widget.bcName]) {
-                bcToLoad[widget.bcName] = widget
+            if (widget.bcName) {
+                let bcName = widget.bcName
+                let parentName = state.screen.bo.bc[widget.bcName].parentName
+                while (parentName) {
+                    bcName = parentName
+                    parentName = state.screen.bo.bc[parentName].parentName
+                }
+
+                if (!bcToLoad[bcName]) {
+                    bcToLoad[bcName] = widget
+                }
             }
         })
-    // Если родитель попал в очередь на загрузку, то дочерние пока не загружаем
-    Object.keys(bcToLoad).forEach(bcName => {
-        const bc = state.screen.bo.bc[bcName]
-        if (bcToLoad[bc.parentName]) {
-            delete bcToLoad[bcName]
-        }
-    })
-    const result = Object.values(bcToLoad).map(widget => {
-        const { name: widgetName, bcName } = widget
+
+    const result = Object.entries(bcToLoad).map(([bcName, widget]) => {
         // TODO: Если получится разобраться с RxJS, то здесь можно бросать
         // конкат от двух Observable - первый на загрузку данных, второй на загрузку меты, отложенный
         // до появления экшна успеха загрузки данных с указанными бк и виджетом
-        return $do.bcFetchDataRequest({ widgetName, bcName })
+        return $do.bcFetchDataRequest({ widgetName: widget.name, bcName })
     })
     return result
 })
@@ -864,16 +854,33 @@ function requestBcChildren(bcName: string) {
     const state = storeInstance.getState()
     const widgets = state.view.widgets
     const bcMap = state.screen.bo.bc
-    // Построим словарь с дочерними БК от запрошенной и виджетами, которые эту БК хотят
-    const childrenBcMap = Object.values(widgets)
-        .filter(widget => widget.bcName && bcMap[widget.bcName].parentName === bcName)
-        .reduce((array, nextWidget) => {
-            if (!array[nextWidget.bcName]) {
-                array[nextWidget.bcName] = []
+
+    // Build a dictionary with children for requested BC and widgets that need this BC
+    const childrenBcMap: ObjectMap<string[]> = {}
+    widgets.forEach((widget) => {
+        if (widget.bcName) {
+            const widgetBcList: string[] = []
+
+            widgetBcList.push(widget.bcName)
+            let parentName = bcMap[widget.bcName] && bcMap[widget.bcName].parentName
+            while (parentName) {
+                widgetBcList.push(parentName)
+                parentName = bcMap[parentName] && bcMap[parentName].parentName
             }
-            array[nextWidget.bcName].push(nextWidget.name)
-            return array
-        }, {} as ObjectMap<string[]>)
+
+            widgetBcList.some((expectedBcName) => {
+                if (bcMap[expectedBcName].parentName === bcName) {
+                    if (!childrenBcMap[expectedBcName]) {
+                        childrenBcMap[expectedBcName] = []
+                    }
+                    childrenBcMap[expectedBcName].push(widget.name)
+                    return true
+                }
+
+                return false
+            })
+        }
+    })
 
     // Если виджет поддерживает иерархию, то поискать дочерний в ней
     // TODO: сделать описание, разбить на хэлперы?

--- a/src/reducers/screen.ts
+++ b/src/reducers/screen.ts
@@ -97,9 +97,9 @@ export function screen(state = initialState, action: AnyAction): ScreenState {
                 .from(
                     new Set(action.payload.widgets.map(widget => widget.bcName)) // БК которые есть на вьюхе
                 )
-                .filter(bcName => state.bo.bc[bcName] && state.bo.bc[bcName].page !== 1)
+                .filter(bcName => state.bo.bc[bcName])
                 .forEach((bcName) => {
-                    newBcs[bcName] = {...state.bo.bc[bcName], page: 1}
+                    newBcs[bcName] = {...state.bo.bc[bcName], page: 1, loading: true}
                 })
             return {
                 ...state,


### PR DESCRIPTION
See #113 

Changes:
Instead of loading only widgets BC data, we now search for their ancestors and start loading data from root BCs.
On view change we mark all widgets BC as "loading", because without this mark we can see empty widget without any loading animation until ancestors BC data is loaded.