### PR TITLE
new WidgetMeta parameter for documentation

### DIFF
--- a/src/interfaces/widget.ts
+++ b/src/interfaces/widget.ts
@@ -172,7 +172,8 @@ export interface WidgetMeta {
     gridWidth: number, // 1-24
     fields: object[],
     options?: WidgetOptions,
-    showCondition?: WidgetShowCondition
+    showCondition?: WidgetShowCondition,
+    documentation?: string // description for documentation
 }
 
 /**


### PR DESCRIPTION
Added new parameter in WidgetMeta.
```
documentation?: string
```
The parameter is needed to describe the widget in the documentation.