### PR TITLE
Make datepicker with empty value keep selected locale (#133)

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,6 +85,12 @@ module.exports = (env, options) => {
                 commonjs2: 'rxjs',
                 commonjs: 'rxjs',
                 amd: 'rxjs'
+            },
+            'moment': {
+                root: 'moment',
+                commonjs2: 'moment',
+                commonjs: 'moment',
+                amd: 'moment'
             }
         }],
         devtool: 'source-map',


### PR DESCRIPTION
See #133 
Fix: force tesler-ui to use same moment.js instance as client application, because by default it uses another instance with default locale when there is no any value in datepicker.