### PR TITLE
fixed an issue with app crash when const page is undefined

### DIFF
--- a/src/components/ColumnTitle/ColumnSort.tsx
+++ b/src/components/ColumnTitle/ColumnSort.tsx
@@ -50,7 +50,7 @@ function mapStateToProps(store: Store, ownProps: ColumnSortOwnProps) {
     const widgetName = widget?.name
     const bcName = widget?.bcName
     const sorter = store.screen.sorters[bcName]?.find(item => item.fieldName === ownProps.fieldKey)
-    const page = store.screen.bo.bc[bcName].page
+    const page = store.screen.bo.bc[bcName]?.page
     const infiniteWidgets: string[] = store.view.infiniteWidgets || []
     const infinitePagination = infiniteWidgets.includes(widgetName)
     return {


### PR DESCRIPTION
If path `store.screen.bo.bc[bcName]` is undefined then the page cannot be found.
