### PR TITLE
Fix an issue with app crash when filterGroups is undefined

### DIFF
--- a/src/components/widgets/TableWidget/TableWidget.tsx
+++ b/src/components/widgets/TableWidget/TableWidget.tsx
@@ -484,7 +484,7 @@ function mapStateToProps(store: Store, ownProps: TableWidgetOwnProps) {
         operations,
         metaInProgress: !!store.view.metaInProgress[bcName],
         filters,
-        filterGroups: store.screen.bo.bc[bcName].filterGroups
+        filterGroups: bc?.filterGroups
     }
 }
 


### PR DESCRIPTION
If path `store.screen.bo.bc[bcName]` is undefined then the filterGroups cannot be found.