### PR TITLE
Missing i18n tokens (#161), `<TableWidget />` headers should not break words.

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -6,9 +6,18 @@
         "Clear all filters": "Clear all filters",
         "Cancel": "Cancel",
         "Ok": "Ok",
+        "Save": "Save",
+        "Delete": "Delete",
         "Are you sure?": "Are you sure?",
         "Perform an additional action?": "Perform an additional action?",
         "The operation is not supported": "The operation is not supported",
-        "Show all": "Show all"
+        "No operations available": "No operations available",
+        "Show all": "Show all",
+        "select file": "select file",
+        "Download": "Download",
+        "Select value": "Select value",
+        "Load more": "Load more",
+        "Required fields are missing": "Required fields are missing",
+        "This field is mandatory": "This field is mandatory"
     }
 }

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -3,15 +3,23 @@
         "Apply": "Применить",
         "Clear": "Сбросить",
         "Required fields are missing": "Не заполнены обязательные поля",
+        "This field is mandatory": "Поле обязательно для заполнения",
         "There are pending changes. Please save them or cancel.": "Остались несохраненные данные. Сохраните или отмените изменения.",
         "Cancel changes": "Отменить изменения",
         "Show all records": "Показать остальные записи",
         "Clear all filters": "Сбросить все фильтры",
         "Cancel": "Отменить",
         "Ok": "Ок",
+        "Save": "Сохранить",
+        "Delete": "Удалить",
         "Are you sure?": "Вы уверены?",
         "Perform an additional action?": "Выполнить дополнительное действие?",
         "The operation is not supported": "Операция не поддерживается",
-        "Show all": "Показать все"
+        "No operations available": "Нет доступных операций",
+        "Show all": "Показать все",
+        "select file": "выберите файл",
+        "Download": "Скачать",
+        "Select value": "Выберите значение",
+        "Load more": "Загрузить еще"
     }
 }

--- a/src/components/ColumnTitle/ColumnTitle.less
+++ b/src/components/ColumnTitle/ColumnTitle.less
@@ -1,5 +1,6 @@
 .container {
     display: flex;
+    word-break: normal;
 }
 
 .sort {

--- a/src/components/FileUpload/FileUpload.tsx
+++ b/src/components/FileUpload/FileUpload.tsx
@@ -9,6 +9,7 @@ import {DataItem} from '../../interfaces/data'
 import {Icon, Upload} from 'antd'
 import {UploadFile} from 'antd/es/upload/interface'
 import cn from 'classnames'
+import {useTranslation} from 'react-i18next'
 import {ChangeDataItemPayload} from '../Field/Field'
 import {axiosInstance} from '../../Provider'
 
@@ -40,6 +41,7 @@ export interface FileUploadActions {
 }
 
 const FileUpload: React.FunctionComponent<FileUploadOwnProps & FileUploadProps & FileUploadActions> = (props) => {
+    const {t} = useTranslation()
     const onUploadSuccess = React.useCallback(
         (response: any, file: UploadFile) => {
             props.onUploadFileDone({
@@ -149,7 +151,7 @@ const FileUpload: React.FunctionComponent<FileUploadOwnProps & FileUploadProps &
     const controls: {[key: string]: React.ReactNode} = {
         deleteButton:
             <div className={styles.deleteButton} onClick={onFileDelete} key="delete-btn">
-                <Icon type="delete" title="Удалить"/>
+                <Icon type="delete" title={t('Delete')} />
             </div>,
 
         uploadButton:
@@ -161,7 +163,7 @@ const FileUpload: React.FunctionComponent<FileUploadOwnProps & FileUploadProps &
                 )}
                 key="upload-btn"
             >
-                <span title="выберите файл" className={styles.uploadButtonText}>...</span>
+                <span title={t('select file')} className={styles.uploadButtonText}>...</span>
             </Upload>,
 
         uploadLink:
@@ -173,11 +175,13 @@ const FileUpload: React.FunctionComponent<FileUploadOwnProps & FileUploadProps &
                 )}
                 key="upload-lnk"
             >
-                <span className={styles.uploadLinkText} title="выберите файл">выберите файл</span>
+                <span className={styles.uploadLinkText} title={t('select file')}>
+                    {t('select file')}
+                </span>
             </Upload>,
 
         downloadLink:
-            <div className={styles.downloadLink} title={`Скачать ${fileName}`} key="download-lnk">
+            <div className={styles.downloadLink} title={`${t('Download')} ${fileName}`} key="download-lnk">
                 <a href={downloadUrl}>
                     <span className={styles.downloadLinkText}>{fileName}</span>
                 </a>

--- a/src/components/ui/Pagination/Pagination.tsx
+++ b/src/components/ui/Pagination/Pagination.tsx
@@ -3,6 +3,7 @@ import {PaginationMode} from '../../../interfaces/widget'
 import {Button} from 'antd'
 import {connect} from 'react-redux'
 import {Dispatch} from 'redux'
+import {useTranslation} from 'react-i18next'
 import {Store} from '../../../interfaces/store'
 import styles from './Pagination.less'
 import {$do} from '../../../actions/actions'
@@ -29,6 +30,7 @@ interface PaginationDispatchProps {
 type PaginationAllProps = PaginationOwnProps & PaginationStateProps & PaginationDispatchProps
 
 const Pagination: React.FunctionComponent<PaginationAllProps> = (props) => {
+    const {t} = useTranslation()
     // disable pagination if not required
     if (!props.hasNext && props.page < 2) {
         return null
@@ -82,7 +84,7 @@ const Pagination: React.FunctionComponent<PaginationAllProps> = (props) => {
                     disabled={props.loading}
                     loading={props.loading}
                 >
-                    Загрузить ещё
+                    {t('Load more')}
                 </Button>
             </div>
             : null

--- a/src/components/ui/PickInput/PickInput.tsx
+++ b/src/components/ui/PickInput/PickInput.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {Input, Icon} from 'antd'
+import {useTranslation} from 'react-i18next'
 import styles from './PickInput.less'
 
 interface PickInputProps {
@@ -11,6 +12,7 @@ interface PickInputProps {
 }
 
 const PickInput: React.FunctionComponent<PickInputProps> = (props) => {
+    const {t} = useTranslation()
     const handleClick = React.useCallback(
         () => {
             if (!props.disabled && props.onClick) {
@@ -31,7 +33,7 @@ const PickInput: React.FunctionComponent<PickInputProps> = (props) => {
         <Input
             disabled={props.disabled}
             readOnly
-            placeholder="Выберите значение"
+            placeholder={t('Select value')}
             value={props.value || ''}
             suffix={clearButton}
             className={props.className}

--- a/src/components/ui/Popup/Popup.tsx
+++ b/src/components/ui/Popup/Popup.tsx
@@ -1,5 +1,6 @@
 import React, {FunctionComponent} from 'react'
 import {Modal, Button} from 'antd'
+import {useTranslation} from 'react-i18next'
 import Pagination from '../../ui/Pagination/Pagination'
 import {PaginationMode} from '../../../interfaces/widget'
 
@@ -25,6 +26,7 @@ const widths = {
 export const Popup: FunctionComponent<PopupProps> = (props) => {
     const title = <h1 className={styles.title}>{props.title}</h1>
     const width = props.size ? widths[props.size] : widths.medium
+    const {t} = useTranslation()
     return <div>
         <Modal
             title={title}
@@ -40,10 +42,10 @@ export const Popup: FunctionComponent<PopupProps> = (props) => {
                     }
                     <div className={styles.actions}>
                         <Button onClick={props.onOkHandler} className={styles.buttonYellow}>
-                            Выбрать
+                            {t('Save')}
                         </Button>
                         <Button onClick={props.onCancelHandler} className={styles.buttonCancel}>
-                            Отмена
+                            {t('Cancel')}
                         </Button>
                     </div>
                 </div>

--- a/src/components/widgets/TableWidget/TableWidget.tsx
+++ b/src/components/widgets/TableWidget/TableWidget.tsx
@@ -300,7 +300,7 @@ export const TableWidget: FunctionComponent<TableWidgetProps> = (props) => {
                             return item
                         })
                         : <Menu.Item disabled>
-                            Нет доступных операций
+                            {t('No operations available')}
                         </Menu.Item>
                 }
             </Menu>

--- a/src/reducers/view.ts
+++ b/src/reducers/view.ts
@@ -4,6 +4,7 @@ import {PendingDataItem} from '../interfaces/data'
 import {Store} from '../interfaces/store'
 import {OperationTypeCrud} from '../interfaces/operation'
 import {buildBcUrl} from '../utils/strings'
+import i18n from 'i18next'
 
 const initialState: ViewState  = {
     id: null,
@@ -203,7 +204,7 @@ export function view(state = initialState, action: AnyAction, store: Store) {
                     || nextPending[fieldKey] === undefined
                     || nextPending[fieldKey] === ''
                 if (required && isEmpty) {
-                    nextValidationFails[fieldKey] = 'Поле обязательно для заполнения'
+                    nextValidationFails[fieldKey] = i18n.t('This field is mandatory')
                 }
             })
             return {


### PR DESCRIPTION
See #161.
Also addresses the problem with `<TableWidget />` column headers breaking words due to antd default styles.