### PR TITLE
New implementation of postInvokeConfirm

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -15,6 +15,7 @@ import {
     OperationTypeCrud,
     AssociatedItem,
     OperationErrorEntity,
+    OperationPostInvokeConfirm,
     OperationPreInvoke
 } from '../interfaces/operation'
 import {BcFilter, BcSorter} from '../interfaces/filters'
@@ -324,13 +325,17 @@ export class ActionPayloadTypes {
      * @param operationType Type of operation to be performed
      * @param widgetName What widget requires data
      * @param onSuccessAction Any other action
-     * @param confirmOperation params for confirm modal
+     * @param confirm params for confirm modal
      */
     sendOperation: {
         bcName: string,
         operationType: OperationTypeCrud | string,
         widgetName: string,
         onSuccessAction?: AnyAction,
+        confirm?: string,
+        /**
+         * @deprecated TODO: Remove in 2.0.0 in favor of sendOperationWithConfirm
+         */
         confirmOperation?: OperationPreInvoke
     } = z
 
@@ -390,6 +395,21 @@ export class ActionPayloadTypes {
         operationType: string
         widgetName: string
         preInvoke: OperationPreInvoke
+    } = z
+
+    /**
+     * Operation to perform postInvokeConfirm actions
+     * 
+     * @param bcName The business component to fetch data for
+     * @param operationType Type of operation to be performed
+     * @param widgetName What widget requires data
+     * @param postInvokeConfirm the action that will be performed after the main operation and confirmation
+     */
+    processPostInvokeConfirm: {
+        bcName: string,
+        operationType: string
+        widgetName: string
+        postInvokeConfirm: OperationPostInvokeConfirm
     } = z
 
     /**
@@ -632,7 +652,7 @@ export class ActionPayloadTypes {
             operationType: OperationTypeCrud | string,
             widgetName: string,
         },
-        confirmOperation: OperationPreInvoke
+        confirmOperation: OperationPostInvokeConfirm
     } = z
 
     /**

--- a/src/components/ModalInvoke/ModalInvoke.less
+++ b/src/components/ModalInvoke/ModalInvoke.less
@@ -1,0 +1,18 @@
+.modal{
+    :global(.ant-modal-close-x) {
+        margin: 0;
+    }
+
+    :global(.ant-btn-primary) {
+        border-color: #f7ad2b;
+        background: #f7ad2b;
+        color: #595959;
+        box-shadow: none;
+
+        &:hover {
+            border-color: #f7ad2b;
+            background: #f7ad2b;
+            color: #595959;
+        }
+    }
+}

--- a/src/components/ModalInvoke/ModalInvoke.tsx
+++ b/src/components/ModalInvoke/ModalInvoke.tsx
@@ -2,43 +2,67 @@ import React from 'react'
 import {Dispatch} from 'redux'
 import {connect} from 'react-redux'
 import {Store} from '../../interfaces/store'
-import {Modal} from 'antd'
+import {Modal, Input} from 'antd'
 import {$do} from '../../actions/actions'
 import {useTranslation} from 'react-i18next'
-import {OperationPreInvoke} from 'interfaces/operation'
+import {OperationPostInvokeConfirmType, OperationPostInvokeConfirm} from '../../interfaces/operation'
+import styles from './ModalInvoke.less'
 
 interface ModalInvokeProps {
     bcName: string,
     operationType: string,
     widgetName: string,
-    confirmOperation: OperationPreInvoke
-    onOk: (bcName: string, operationType: string, widgetName: string, postInvokeConfirm: OperationPreInvoke) => void,
+    confirmOperation: OperationPostInvokeConfirm
+    onOk: (bcName: string, operationType: string, widgetName: string, confirm: string) => void,
     onCancel: () => void,
 }
 
 const ModalInvoke: React.FunctionComponent<ModalInvokeProps> = (props) => {
     const {t} = useTranslation()
-    const modal = Modal.confirm({
-        title: props.confirmOperation?.message || t('Perform an additional action?'),
-        content: t('Are you sure?'),
-        okText: t('Ok'),
-        cancelText: t('Cancel')
-    })
-    modal.update({
-        onOk: () => {
+    const [value, setValue] = React.useState('')
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setValue(e.target.value || null)
+    }
+
+    const getContent = () => {
+        switch (props.confirmOperation.type) {
+            case OperationPostInvokeConfirmType.confirm: {
+                return <div>
+                    <p>{props.confirmOperation?.messageContent || t('Are you sure?')}</p>
+                </div>
+            }
+            case OperationPostInvokeConfirmType.confirmText: {
+                return <div>
+                {props.confirmOperation?.messageContent && <p>{props.confirmOperation?.messageContent}</p>}
+                {<Input value={value} onChange={handleChange}/>}
+            </div>
+            }
+            default:
+                return null
+        }
+    }
+
+    return <Modal
+        className={styles.modal}
+        visible={true}
+        title={props.confirmOperation?.message || t('Perform an additional action?')}
+        okText={t('Ok')}
+        cancelText={t('Cancel')}
+        onOk={() => {
             props.onOk(
                 props.bcName,
                 props.operationType,
                 props.widgetName,
-                props.confirmOperation
+                value || 'ok'
             )
-            modal.destroy()
-        },
-        onCancel: () => {
+        }}
+        onCancel={() => {
             props.onCancel()
-        }
-    })
-    return null
+        }}
+    >
+        {getContent()}
+    </Modal>
 }
 
 function mapStateToProps(store: Store) {
@@ -53,8 +77,8 @@ function mapStateToProps(store: Store) {
 
 function mapDispatchToProps(dispatch: Dispatch) {
     return {
-        onOk: (bcName: string, operationType: string, widgetName: string, confirmOperation?: OperationPreInvoke) => {
-            dispatch($do.sendOperation({ bcName, operationType, widgetName, confirmOperation}))
+        onOk: (bcName: string, operationType: string, widgetName: string, confirm?: string) => {
+            dispatch($do.sendOperation({ bcName, operationType, widgetName, confirm}))
             dispatch($do.closeConfirmModal(null))
         },
         onCancel: () => {

--- a/src/epics/screen.ts
+++ b/src/epics/screen.ts
@@ -8,7 +8,7 @@ import {
     OperationPostInvokeShowMessage,
     OperationPostInvokeDownloadFile,
     OperationPostInvokeDownloadFileByUrl,
-    OperationPreInvokeType
+    OperationPostInvokeConfirmType
 } from '../interfaces/operation'
 import {ObjectMap} from '../interfaces/objectMap'
 import {historyObj} from '../reducers/router'
@@ -110,19 +110,24 @@ const downloadFileByUrl: Epic = (action$, store) => action$.ofType(types.downloa
     return Observable.empty()
 })
 
-const processPreInvoke: Epic = (action$, store) => action$.ofType(types.processPreInvoke)
+const processPostInvokeConfirm: Epic = (action$, store) => action$.ofType(types.processPostInvokeConfirm, types.processPreInvoke)
 .mergeMap((action) => {
-    switch (action.payload.preInvoke.type) {
-        case OperationPreInvokeType.confirm:
-            const {bcName, operationType, widgetName, preInvoke} = action.payload
+    const {bcName, operationType, widgetName} = action.payload
+    const confirm = action.type === types.processPostInvokeConfirm
+        ? action.payload.postInvokeConfirm
+        : action.payload.preInvoke
+    switch (confirm.type) {
+        case OperationPostInvokeConfirmType.confirm:
+        case OperationPostInvokeConfirmType.confirmText: {
             return Observable.of($do.operationConfirmation({
                 operation: {
                     bcName,
                     operationType,
                     widgetName,
                 },
-                confirmOperation: preInvoke
+                confirmOperation: confirm
             }))
+        }
         default:
             return Observable.empty()
     }
@@ -132,5 +137,5 @@ export const screenEpics = combineEpics(
     processPostInvoke,
     downloadFile,
     downloadFileByUrl,
-    processPreInvoke
+    processPostInvokeConfirm
 )

--- a/src/interfaces/data.ts
+++ b/src/interfaces/data.ts
@@ -1,4 +1,4 @@
-import {OperationPostInvokeAny, OperationPreInvoke} from './operation'
+import {OperationPostInvokeAny, OperationPostInvokeConfirm, OperationPreInvoke} from './operation'
 import {DrillDownType} from './router'
 
 /**
@@ -58,6 +58,10 @@ export interface DataItemResponse {
     data: {
         record: DataItem,
         postActions?: OperationPostInvokeAny[],
+        postInvokeConfirm?: OperationPostInvokeConfirm,
+        /*
+        * @deprecated TODO: Remove in 2.0.0 in favor of postInvokeConfirm
+        */
         preInvoke?: OperationPreInvoke
     }
 }

--- a/src/interfaces/operation.ts
+++ b/src/interfaces/operation.ts
@@ -47,7 +47,7 @@ export type OperationType = OperationTypeCrud | string
  * @param scope - ???
  * @param preInvoke - действие, которое надо произвести прежде чем начать выполнять операцию
  * @param autoSaveBefore Validate the record for empty "required" fields before API call
- * @param confirmOperation Data for preInvoke confirm action
+ * @param confirmOperation Data for postInvokeConfirm action
  */
 export interface Operation {
     text: string,
@@ -148,6 +148,33 @@ export const enum OperationPostInvokeType {
      * Не использовать и убрать с Досье, когда определимся с форматом ответов
      */
     postDelete = 'postDelete'
+}
+
+/**
+ * The type of message that will be shown to the user for confirmation
+ */
+export enum OperationPostInvokeConfirmType {
+    /**
+     * Simple confirmation
+     */
+    confirm = 'confirm',
+    /**
+     * Сonfirmation with text from the user
+     */
+    confirmText = 'confirmText'
+}
+
+/**
+ * The action that will be performed after the user confirms it
+ *
+ * @param type Type of postInvokeConfirm action
+ * @param message Title for modal
+ * @param messageContent Additional text for modal
+ */
+export interface OperationPostInvokeConfirm {
+    type: OperationPostInvokeConfirmType | string,
+    message: string,
+    messageContent?: string
 }
 
 /**

--- a/src/interfaces/view.ts
+++ b/src/interfaces/view.ts
@@ -2,7 +2,7 @@ import {WidgetMeta} from '../interfaces/widget'
 import {RowMeta} from '../interfaces/rowMeta'
 import {PendingDataItem, PickMap} from '../interfaces/data'
 import {SystemNotification} from './objectMap'
-import {OperationTypeCrud, OperationPreInvoke} from './operation'
+import {OperationTypeCrud, OperationPostInvokeConfirm} from './operation'
 
 export interface ViewSelectedCell {
     widgetName: string,
@@ -42,7 +42,7 @@ export interface ViewState extends ViewMetaResponse {
             operationType: OperationTypeCrud | string,
             widgetName: string,
         }
-        confirmOperation: OperationPreInvoke
+        confirmOperation: OperationPostInvokeConfirm,
     },
 }
 


### PR DESCRIPTION
New implementation of postInvokeConfirm

If the `postInvokeConfirm` parameter is returned in response to the `CustomAction` request, a modal window will appear to confirm the action.

postInvokeConfirm has the following type:
```
{
  type: OperationPostInvokeConfirmType, // Type of postInvokeConfirm action
  message: string,  // Title for modal
  messageContent?: string //Additional text for modal
}
```
there are two types of posInvokeConfirm:
`confirm` - Simple confirmation
`confirmText` - Confirmation with input for user text