### PR TITLE
Default screen view as screen.primaryView

### DIFF
--- a/src/epics/router.ts
+++ b/src/epics/router.ts
@@ -71,7 +71,9 @@ const changeLocation: Epic = (action$, store) => action$.ofType(types.changeLoca
     if (needUpdateViews) {
         const nextView = nextViewName
             ? state.screen.views.find(item => item.name === nextViewName)
-            : state.screen.views[0]
+            : state.screen.primaryView
+                ? state.screen.views.find(item => item.name === state.screen.primaryView)
+                : state.screen.views[0]
         resultObservables.push(
             nextView
                 ? Observable.of($do.selectView(nextView))


### PR DESCRIPTION
When the ChangeLocation action is executed and the ViewName parameter is not specified, then switch to the view from screen.primaryView, instead of screen.views [0]. 
If screen.primaryView is missing too, then use screen.views [0].