### PR TITLE
Add Modal Invoke window for info and error invoke types (#216)

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -11,6 +11,8 @@
         "Delete": "Delete",
         "Are you sure?": "Are you sure?",
         "Perform an additional action?": "Perform an additional action?",
+        "Action cannot be performed": "Action cannot be performed",
+        "Action has warning": "Action has warning",
         "The operation is not supported": "The operation is not supported",
         "No operations available": "No operations available",
         "No data": "No data",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -15,6 +15,8 @@
         "Delete": "Удалить",
         "Are you sure?": "Вы уверены?",
         "Perform an additional action?": "Выполнить дополнительное действие?",
+        "Action cannot be performed": "Действие не может быть выполнено",
+        "Action has warning": "Действие имеет предупреждение",
         "The operation is not supported": "Операция не поддерживается",
         "No operations available": "Нет доступных операций",
         "No data": "Нет данных",

--- a/src/components/ModalInvoke/ModalInvoke.less
+++ b/src/components/ModalInvoke/ModalInvoke.less
@@ -14,5 +14,10 @@
             background: #f7ad2b;
             color: #595959;
         }
+        &:focus {
+            border-color: #f7ad2b;
+            background: #f7ad2b;
+            color: #595959;
+        }
     }
 }

--- a/src/components/ModalInvoke/ModalInvoke.tsx
+++ b/src/components/ModalInvoke/ModalInvoke.tsx
@@ -5,14 +5,14 @@ import {Store} from '../../interfaces/store'
 import {Modal, Input} from 'antd'
 import {$do} from '../../actions/actions'
 import {useTranslation} from 'react-i18next'
-import {OperationPostInvokeConfirmType, OperationPostInvokeConfirm} from '../../interfaces/operation'
+import {OperationPostInvokeConfirmType, OperationModalInvokeConfirm, OperationPreInvokeType} from '../../interfaces/operation'
 import styles from './ModalInvoke.less'
 
 interface ModalInvokeProps {
     bcName: string,
     operationType: string,
     widgetName: string,
-    confirmOperation: OperationPostInvokeConfirm
+    confirmOperation: OperationModalInvokeConfirm
     onOk: (bcName: string, operationType: string, widgetName: string, confirm: string) => void,
     onCancel: () => void,
 }
@@ -29,40 +29,86 @@ const ModalInvoke: React.FunctionComponent<ModalInvokeProps> = (props) => {
         switch (props.confirmOperation.type) {
             case OperationPostInvokeConfirmType.confirm: {
                 return <div>
-                    <p>{props.confirmOperation?.messageContent || t('Are you sure?')}</p>
+                    <p>{props.confirmOperation?.message || t('Perform an additional action?')}</p>
                 </div>
             }
             case OperationPostInvokeConfirmType.confirmText: {
                 return <div>
-                {props.confirmOperation?.messageContent && <p>{props.confirmOperation?.messageContent}</p>}
-                {<Input value={value} onChange={handleChange}/>}
-            </div>
+                    {props.confirmOperation?.message && <p>{props.confirmOperation?.message}</p>}
+                    {<Input value={value} onChange={handleChange}/>}
+                </div>
+            }
+            case OperationPreInvokeType.info: {
+                return <div>
+                    <p>{props.confirmOperation?.message || t('Action has warning')}</p>
+                </div>
+            }
+            case OperationPreInvokeType.error: {
+                return <div>
+                    <p>{props.confirmOperation?.message || t('Action cannot be performed')}</p>
+                </div>
             }
             default:
                 return null
         }
     }
 
-    return <Modal
-        className={styles.modal}
-        visible={true}
-        title={props.confirmOperation?.message || t('Perform an additional action?')}
-        okText={t('Ok')}
-        cancelText={t('Cancel')}
-        onOk={() => {
-            props.onOk(
-                props.bcName,
-                props.operationType,
-                props.widgetName,
-                value || 'ok'
-            )
-        }}
-        onCancel={() => {
-            props.onCancel()
-        }}
-    >
-        {getContent()}
-    </Modal>
+    switch (props.confirmOperation.type) {
+        case OperationPreInvokeType.info: {
+            const modal = Modal.info({
+                className: styles.modal,
+                title: props.confirmOperation?.messageContent,
+                okText: t('Ok'),
+                onOk: () => {
+                    props.onOk(
+                        props.bcName,
+                        props.operationType,
+                        props.widgetName,
+                        value || 'ok'
+                    )
+                    modal.destroy()
+                },
+                content: getContent(),
+
+            })
+            return null
+        }
+        case OperationPreInvokeType.error: {
+            const modal = Modal.error({
+                className: styles.modal,
+                title: props.confirmOperation?.messageContent,
+                okText: t('Ok'),
+                onOk: () => {
+                    props.onCancel()
+                    modal.destroy()
+                },
+                content: getContent(),
+            })
+            return null
+        }
+        default: {
+            return <Modal
+                className={styles.modal}
+                visible={true}
+                title={props.confirmOperation?.messageContent || t('Are you sure?')}
+                okText={t('Ok')}
+                cancelText={t('Cancel')}
+                onOk={() => {
+                    props.onOk(
+                        props.bcName,
+                        props.operationType,
+                        props.widgetName,
+                        value || 'ok'
+                    )
+                }}
+                onCancel={() => {
+                    props.onCancel()
+                }}
+            >
+                {getContent()}
+            </Modal>
+        }
+    }
 }
 
 function mapStateToProps(store: Store) {

--- a/src/epics/screen.ts
+++ b/src/epics/screen.ts
@@ -8,7 +8,7 @@ import {
     OperationPostInvokeShowMessage,
     OperationPostInvokeDownloadFile,
     OperationPostInvokeDownloadFileByUrl,
-    OperationPostInvokeConfirmType
+    OperationPostInvokeConfirmType, OperationPreInvokeType
 } from '../interfaces/operation'
 import {ObjectMap} from '../interfaces/objectMap'
 import {historyObj} from '../reducers/router'
@@ -118,6 +118,8 @@ const processPostInvokeConfirm: Epic = (action$, store) => action$.ofType(types.
         : action.payload.preInvoke
     switch (confirm.type) {
         case OperationPostInvokeConfirmType.confirm:
+        case OperationPreInvokeType.info:
+        case OperationPreInvokeType.error:
         case OperationPostInvokeConfirmType.confirmText: {
             return Observable.of($do.operationConfirmation({
                 operation: {

--- a/src/interfaces/operation.ts
+++ b/src/interfaces/operation.ts
@@ -178,6 +178,19 @@ export interface OperationPostInvokeConfirm {
 }
 
 /**
+ * Modal window operation types
+ *
+ * @param type Type of postInvokeConfirm action
+ * @param message Title for modal
+ * @param messageContent Additional text for modal
+ */
+export interface OperationModalInvokeConfirm {
+    type: OperationPostInvokeConfirmType | OperationPreInvokeType | string,
+    message: string,
+    messageContent?: string
+}
+
+/**
  * Действие, которое будет выполнено после операции пользователя
  *
  * @param type Тип действия


### PR DESCRIPTION
Each custom action may be able to perform an additional Invoke operation before and after its execution. Invoke operation displays a modal window for the user. The action will be executed depending on the contents of the modal window and user actions.

The `ModalInvoke` component can be called by the operations` preInvoke` and `postInvoke`. In general, `preInvoke` is an indicator that the next `postAction `implements a condition for further behavior. However, `ModalInvoke` can be used as a reaction to `preInvoke` in simple behavior.
In this case, it is necessary for `ModalInvoke `to be able to process all types of Invoke.

`ModalInvoke` component have been changed, allowing to display modal windows for `info` and `error` invoke types.

* type `info` displays a warning. Сlick on the button is execute custom action.
* type `error` displays an error message. Сlick on the button is **not** execute custom action.
* other types display a window with two buttons. The `OK` button execute custom action, the `CANCEL` button does not.