### PR TITLE
Autosave middleware reserved for tables erroneously applied to other widgets by `requiredFieldsMiddleware` (#257)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ const parseLocation = getParseLocationInstance
 const buildLocation = getBuildLocationInstance
 
 import {isViewNavigationItem, isViewNavigationCategory, isViewNavigationGroup} from './interfaces/navigation'
-import {isWidgetFieldBlock} from './interfaces/widget'
+import {isWidgetFieldBlock, TableLikeWidgetTypes} from './interfaces/widget'
 
 export {
     Provider,
@@ -50,5 +50,6 @@ export {
     isViewNavigationItem,
     isViewNavigationCategory,
     isViewNavigationGroup,
-    isWidgetFieldBlock
+    isWidgetFieldBlock,
+    TableLikeWidgetTypes
 }

--- a/src/interfaces/widget.ts
+++ b/src/interfaces/widget.ts
@@ -20,6 +20,17 @@ export const enum WidgetTypes {
     Text = 'Text'
 }
 
+/**
+ * Different widget types that are considered `tables` in nature for purposes of applying some shared features.
+ * For example, autofocus on missing required field should work for tables but not forms.
+ */
+export const TableLikeWidgetTypes: Array<WidgetTypes | string> = [
+    WidgetTypes.List,
+    WidgetTypes.DataGrid,
+    WidgetTypes.AssocListPopup,
+    WidgetTypes.PickListPopup
+]
+
 export interface WidgetFieldBase {
     type: FieldType,
     key: string,


### PR DESCRIPTION
* Fix the problem of #257
* Export `TableLikeWidgetTypes` array for some shared features between table like widgets; intention is that it's available for customization by client app, although we might move to a getter instead