### PR TITLE
Added the ability to crop string fields and put three dots in the end

### DIFF
--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -44,6 +44,7 @@ interface FieldOwnProps {
     forcedValue?: DataValue,
     historyMode?: boolean,
     customProps?: Record<string, any>,
+    maxValueLength?: number
 }
 
 interface FieldProps extends FieldOwnProps {
@@ -86,12 +87,24 @@ const emptyFieldMeta = [] as any
 export const Field: FunctionComponent<FieldProps> = (props) => {
     const [localValue, setLocalValue] = React.useState(null)
     let resultField: React.ReactChild = null
+    const cutSring = (inputStr: string) => {
+        if (inputStr.length > props.maxValueLength) {
+            const endWordIndex = inputStr.indexOf(' ', props.maxValueLength)
+            return endWordIndex > 0
+              ? `${inputStr.substring(0, endWordIndex)}...`
+              : inputStr
+        }
+        else
+          return inputStr
+    }
 
     const value = ('forcedValue' in props)
         ? props.forcedValue
         : (props.pendingValue !== undefined)
             ? props.pendingValue
-            : props.data?.[props.widgetFieldMeta.key]
+            : (props.maxValueLength && typeof props.data?.[props.widgetFieldMeta.key] === 'string')
+              ? cutSring(props.data?.[props.widgetFieldMeta.key]?.toString())
+              : props.data?.[props.widgetFieldMeta.key]
 
     const disabled = (props.rowFieldMeta ? props.rowFieldMeta.disabled : true)
 

--- a/src/components/widgets/TableWidget/TableWidget.tsx
+++ b/src/components/widgets/TableWidget/TableWidget.tsx
@@ -35,7 +35,8 @@ interface TableWidgetOwnProps {
     paginationMode?: PaginationMode,
     disablePagination?: boolean,
     disableDots?: boolean,
-    controlColumns?: Array<{column: ColumnProps<DataItem>, position: 'left' | 'right'}>
+    controlColumns?: Array<{column: ColumnProps<DataItem>, position: 'left' | 'right'}>,
+    maxFieldValueLength?: number
 }
 
 export interface TableWidgetProps extends TableWidgetOwnProps {
@@ -346,6 +347,7 @@ export const TableWidget: FunctionComponent<TableWidgetProps> = (props) => {
                                 widgetFieldMeta={item}
                                 readonly={!editMode}
                                 forceFocus={editMode}
+                                maxValueLength={props.maxFieldValueLength}
                             />
                         </div>
                     },


### PR DESCRIPTION
For Field added a new optional parameter:
`maxValueLength` - this parameter means the maximum allowed number of symbols in the field, after which the end of the word will be found and three dots will be placed

For TableWidget also added optional parameter:
`maxFieldValueLength` - similar parameter for a table to reduce the number of symbols in the table field