### PR TITLE
TableWidget: Added `columnTitleComponent` prop

### DIFF
--- a/src/components/widgets/TableWidget/TableWidget.test.tsx
+++ b/src/components/widgets/TableWidget/TableWidget.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {ReactElement} from 'react'
 import {shallow} from 'enzyme'
 import {TableWidget, TableWidgetProps} from './TableWidget'
 import {WidgetTableMeta, WidgetTypes} from 'interfaces/widget'
@@ -72,5 +72,22 @@ describe('TableWidget test', () => {
         />)
         expect(wrapper.find(Table).length).toEqual(1)
         expect(wrapper.find(Table).props().columns.length).toEqual(1)
+    })
+
+    it('should render custom column title', () => {
+        const customTitleText = 'Some title'
+        const wrapper1 = shallow(<TableWidget
+            {...restProps}
+            meta={{...hideFieldProps}}
+        />)
+        const wrapper = shallow(<TableWidget
+            {...restProps}
+            meta={{...hideFieldProps}}
+            columnTitleComponent={() => <div>{customTitleText}</div>}
+        />)
+        expect(wrapper.find(Table).props().columns.findIndex(i => (i.title as ReactElement).props.children === customTitleText)).toEqual(0)
+        expect(wrapper1.find(Table).props().columns.findIndex(
+            i => (i.title as ReactElement).props.widgetName === hideFieldProps.name
+            )).toEqual(0)
     })
 })

--- a/src/components/widgets/TableWidget/TableWidget.tsx
+++ b/src/components/widgets/TableWidget/TableWidget.tsx
@@ -28,6 +28,11 @@ import {parseFilters} from '../../../utils/filters'
 import Select from '../../ui/Select/Select'
 
 interface TableWidgetOwnProps {
+    columnTitleComponent?: (options?: {
+        widgetName: string,
+        widgetMeta: WidgetListField,
+        rowMeta: RowMetaField
+    }) => React.ReactNode,
     meta: WidgetTableMeta,
     rowSelection?: TableRowSelection<DataItem>,
     showRowActions?: boolean,
@@ -329,7 +334,9 @@ export const TableWidget: FunctionComponent<TableWidgetProps> = (props) => {
             .map((item: WidgetListField) => {
                 const fieldRowMeta = props.rowMetaFields?.find(field => field.key === item.key)
                 return {
-                    title: <ColumnTitle
+                    title: props.columnTitleComponent
+                        ? props.columnTitleComponent({widgetName: props.meta.name, widgetMeta: item, rowMeta: fieldRowMeta})
+                        : <ColumnTitle
                         widgetName={props.meta.name}
                         widgetMeta={item}
                         rowMeta={fieldRowMeta}


### PR DESCRIPTION
This prop allows to pass custom component to column title (#218)

For example:
```columnTitleComponent={() => <div>Some title</div>}```

or

```
import {TableWidget as CoreTableWidget} from '@tesler-ui/core'
...

function TableWidget(props: TableWidgetProps) {

const renderColumnTitle = React.useCallback(
        (pr: {widgetName: string, widgetMeta: WidgetListField, rowMeta: RowMetaField}) =>
            <CustomColumnTitle
                widgetName={pr.widgetName}
                widgetMeta={pr.widgetMeta}
                rowMeta={pr.rowMeta}
            />,
        []
    )

return <CoreTableWidget
        {...props}
        columnTitleComponent={renderSmColumnTitle}
    />
}
```