### PR TITLE
Alpha version ^1.15.8-alpha.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tesler-ui/core",
-  "version": "1.15.6",
+  "version": "1.15.7",
   "main": "tesler-ui-core.js",
   "homepage": "https://tesler.io/",
   "types": "index.d.ts",


### PR DESCRIPTION
alpha version ^1.15.8-alpha.0
Fixes:
- PreInvokeMiddleware
- Select all checkbox in FullHierarchyTable
- Basis for the save number of Tablewidget records
- FullHierarcy search support
- PickListPopup remove footer buttons and fix title
- MVG field open icon inactive without popup widget rowMeta
- confirm popup BC
- wait data and rowMeta in HierarcyTable on ListWidget
- default expand level up