### PR TITLE
Alignment of columns in the FullHierarchyTable, due to setting the width

### DIFF
--- a/src/components/FullHierarchyTable/FullHierarchyTable.less
+++ b/src/components/FullHierarchyTable/FullHierarchyTable.less
@@ -5,16 +5,6 @@
 
 .container :global(.ant-table-tbody) > tr > td {
     border-bottom: none;
-
-    .padding1 {
-        padding-left: 40px;
-    }
-    .padding2 {
-        padding-left: 70px;
-    }
-    .padding3 {
-        padding-left: 90px;
-    }
 }
 
 .table {
@@ -23,4 +13,16 @@
 
 .selectColumn {
     text-align: center;
+}
+
+.padding1 {
+    padding-left: 40px;
+}
+
+.padding2 {
+    padding-left: 70px;
+}
+
+.padding3 {
+    padding-left: 90px;
 }

--- a/src/components/FullHierarchyTable/FullHierarchyTable.less
+++ b/src/components/FullHierarchyTable/FullHierarchyTable.less
@@ -5,6 +5,16 @@
 
 .container :global(.ant-table-tbody) > tr > td {
     border-bottom: none;
+
+    .padding1 {
+        padding-left: 40px;
+    }
+    .padding2 {
+        padding-left: 70px;
+    }
+    .padding3 {
+        padding-left: 90px;
+    }
 }
 
 .table {

--- a/src/components/FullHierarchyTable/FullHierarchyTable.tsx
+++ b/src/components/FullHierarchyTable/FullHierarchyTable.tsx
@@ -13,6 +13,7 @@ import MultivalueHover from '../ui/Multivalue/MultivalueHover'
 import Field from '../Field/Field'
 import {useAssocRecords} from '../../hooks/useAssocRecords'
 import {$do} from '../../actions/actions'
+import cn from 'classnames'
 
 export interface FullHierarchyTableOwnProps {
     meta: WidgetTableMeta,
@@ -169,8 +170,8 @@ export const FullHierarchyTable: React.FunctionComponent<FullHierarchyTableAllPr
         title: '',
         key: '_indentColumn',
         dataIndex: null as string,
-        className: styles.selectColumn,
-        width: `${50 + indentLevel * 50}px`,
+        className: cn(styles.selectColumn, styles[`padding${indentLevel}`]),
+        width: '100px',
         render: (text: string, dataItem: AssociatedItem): React.ReactNode => {
             return null
         }
@@ -185,6 +186,8 @@ export const FullHierarchyTable: React.FunctionComponent<FullHierarchyTableAllPr
                     title: item.title,
                     key: item.key,
                     dataIndex: item.key,
+                    width: item.width || null,
+                    className: cn({[styles[`padding${indentLevel}`]]: fields[0].key === item.key && indentLevel}),
                     render: (text: string, dataItem: any) => {
                         if (item.type === FieldType.multivalue) {
                             return <MultivalueHover


### PR DESCRIPTION
Now you can set the column width in FullHierarchyTable

To do this, in the widget meta in the field description, you need to add key `width: string | number`

```
{ key: "fieldKey", title: "fieldTitle", type: "input", width: "100px" }
```
or
```
{ key: "fieldKey", title: "fieldTitle", type: "input", width: 100 }
```