### PR TITLE
Added workflow which allows to build `alpha` package

### DIFF
--- a/.github/workflows/build-alpha-from-pr.yml
+++ b/.github/workflows/build-alpha-from-pr.yml
@@ -1,0 +1,68 @@
+# This is a basic workflow to help you get started with Actions
+
+name: build-alpha-from-pr
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  issue_comment:
+    types: [created]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build-alpha:
+    name: Build alpha package
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/alpha')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Get package version
+        uses: nyaascii/package-version@v1
+
+      - name: Show env
+        run: |
+          echo "Package version ${{ env.PACKAGE_VERSION }}"
+
+      - name: Grep version fron NPM registry
+        id: grep_version
+        run: |
+          echo "##[set-output name=current_version;]$(yarn info @tesler-ui/core versions | grep -Eo "${{ env.PACKAGE_VERSION }}(-alpha[0-9]{1,})?" | sort -r | head -1 | xargs echo)"
+
+      - name: Bump release version
+        id: bump_version
+        uses: DRITE/increment-semantic-version@fix/incrementation-preversion
+        with:
+          current-version: '${{ steps.grep_version.outputs.current_version }}'
+          version-fragment: 'alpha'
+
+      - name: Check bump
+        run: echo "bumped.. ${{ steps.bump_version.outputs.next-version }}"
+
+      - name: Increase version
+        run: |
+          git config --global user.name "github"
+          git config --global user.email "dergachev@hotmail.com"
+          yarn version --new-version ${{ steps.bump_version.outputs.next-version }}
+
+      - name: install
+        run: yarn install
+
+      - name: linter
+        run: yarn lint
+
+      - name: build
+        run: yarn build
+
+      - name: Publish dist to NPM
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
+          cd dist
+          yarn publish --tag alpha --access public
+          cd ..
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+


### PR DESCRIPTION
If you have PR and would like to check your feature before merge, then just leave the comment `/alpha` under your PR.

### Algorithm
Let  current version of package be `1.15.0`. 
Workflow checks if NPM registry contains alpha versions of that package. 
If doesn't contains, then version `1.15.0-alpha0` will be published. 
If contains, then workflow will increase present version. For example: `1.15.0-alpha1` -> `1.15.0-alpha2`

With this workflow  there is no need in `alpha` branch.