### PR TITLE
Fixed bug when preInvoke doesn`t work if you use operation in dots menu

### DIFF
--- a/src/components/widgets/TableWidget/TableWidget.tsx
+++ b/src/components/widgets/TableWidget/TableWidget.tsx
@@ -16,7 +16,7 @@ import Field, {emptyMultivalue} from '../../Field/Field'
 import MultivalueHover from '../../ui/Multivalue/MultivalueHover'
 import {Route} from '../../../interfaces/router'
 import {useWidgetOperations} from '../../../hooks'
-import {Operation, OperationGroup} from '../../../interfaces/operation'
+import {Operation, OperationGroup, OperationPreInvoke} from '../../../interfaces/operation'
 import ColumnTitle from '../../ColumnTitle/ColumnTitle'
 import cn from 'classnames'
 import Pagination from '../../ui/Pagination/Pagination'
@@ -74,7 +74,7 @@ export interface TableWidgetProps extends TableWidgetOwnProps {
     onDrillDown?: (widgetName: string, bcName: string, cursor: string, fieldKey: string) => void,
     // TODO: Remove `route` in 2.0 as it is accessible from the store; remove `bcName`
     onShowAll: (bcName: string, cursor: string, route: Route, widgetName: string) => void,
-    onOperationClick: (bcName: string, operationType: string, widgetName: string) => void,
+    onOperationClick: (bcName: string, operationType: string, widgetName: string, confirmOperation?: OperationPreInvoke) => void,
     onSelectRow: (bcName: string, cursor: string) => void,
     onSelectCell: (cursor: string, widgetName: string, fieldKey: string) => void,
     onRemoveFilters: (bcName: string) => void,
@@ -303,7 +303,7 @@ export const TableWidget: FunctionComponent<TableWidgetProps> = (props) => {
                                     key={operation.type}
                                     onClick={() => {
                                         onMenuVisibilityChange(false) // Dropdown bug: doesn't call onVisibleChange on menu item click
-                                        props.onOperationClick(props.meta.bcName, operation.type, props.meta.name)
+                                        props.onOperationClick(props.meta.bcName, operation.type, props.meta.name, operation.preInvoke)
                                     }}
                                 >
                                     { operation.icon && <Icon type={operation.icon} className={styles.icon} /> }
@@ -574,8 +574,8 @@ function mapDispatchToProps(dispatch: Dispatch) {
          * @deprecated TODO: Remove in 2.0
          */
         onDrillDown: null as (widgetName: string, cursor: string, bcName: string, fieldKey: string) => void,
-        onOperationClick: (bcName: string, operationType: string, widgetName: string) => {
-            dispatch($do.sendOperation({ bcName, operationType, widgetName }))
+        onOperationClick: (bcName: string, operationType: string, widgetName: string, confirmOperation?: OperationPreInvoke) => {
+            dispatch($do.sendOperation({ bcName, operationType, widgetName, confirmOperation }))
         },
         onSelectRow: (bcName: string, cursor: string) => {
             dispatch($do.bcSelectRecord({ bcName, cursor }))


### PR DESCRIPTION
Fixed bug when preInvoke doesn`t work if you use operation in dots menu in the TableWidget