### PR TITLE
Drildown with filters ability remove filter

### DIFF
--- a/src/epics/router.ts
+++ b/src/epics/router.ts
@@ -16,11 +16,11 @@ import {parsePath} from 'history'
 import {parseFilters, parseSorters} from '../utils/filters'
 
 /**
- * Эпик смены текущего маршрута
+ * Epic of changing the current route
  *
- * Проверяет параметры маршрута (скрин, вью, курсоры БК) относительно тех,
- * что сейчас хранятся в сторе, и в случае несовпадения инициирует перезагрузку
- * скрина, вьюхи или БК с новыми курсорами.
+ * Checks route parameters (screen, view, BC cursors) relative to those
+ * that are currently stored in the store, and in case of a mismatch
+ * initiates reloading the screen, view or BC with new cursors.
  */
 const changeLocation: Epic = (action$, store) => action$.ofType(types.changeLocation)
 .mergeMap(action => {
@@ -181,12 +181,16 @@ const drillDown: Epic = (action$, store) => action$.ofType(types.drillDown)
                     if (urlFilters) {
                         const filters = JSON.parse(urlFilters)
                         Object.keys(filters).map((bcName) => {
-                            const parsedFilters = parseFilters(filters[bcName])
-                            parsedFilters.forEach((item) => {
-                                store.dispatch($do.bcAddFilter({bcName, filter: item}))
-                            })
-                            if (!diff.length) {
-                                store.dispatch($do.bcForceUpdate({bcName}))
+                            if (filters[bcName].length) {
+                                const parsedFilters = parseFilters(filters[bcName])
+                                parsedFilters.forEach((item) => {
+                                    store.dispatch($do.bcAddFilter({bcName, filter: item}))
+                                })
+                                if (!diff.length) {
+                                    store.dispatch($do.bcForceUpdate({bcName}))
+                                }
+                            } else {
+                                store.dispatch($do.bcRemoveAllFilters({bcName}))
                             }
                         })
                     }

--- a/src/reducers/screen.ts
+++ b/src/reducers/screen.ts
@@ -385,7 +385,7 @@ export function screen(state = initialState, action: AnyAction): ScreenState {
         case types.bcRemoveFilter: {
             const { bcName, filter } = action.payload
             const prevFilters = state.filters[bcName] || []
-            const newFilters = prevFilters.filter(item => item.fieldName !== filter.fieldName || item.type !== item.type)
+            const newFilters = prevFilters.filter(item => item.fieldName !== filter?.fieldName || item.type !== item.type)
             return {
                 ...state,
                 bo: {


### PR DESCRIPTION
Drildown with filters can remove all filters on current BC (#360). 

Filter url must contain JSON in which the `filters` parameter is specified, containing name of the BC. The filter string must be empty.

Example drilldown url: 
`"/screen/view?filters={"bcName":""}"`

------------------------
Bugfix:

When filter with an empty value is added to a table column, the bcRemoveFilter filter cleanup action will be executed (ColumnFilter.tsx 104). bcRemoveFilter action was crash if bc have current filters in this case.
