### PR TITLE
Incorrect check for `autoSaveBefore` in 1.18.0 causes required fields validation when it shouldn't (e.g. cancel operations) (#368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Empty business component filter in the url should clear filters for this bc ([#360](https://github.com/tesler-platform/tesler-ui/issues/360))
 * Adding empty filter crashes the application if there was already present non-empty filter ([#360](https://github.com/tesler-platform/tesler-ui/issues/360))
+* Incorrect check for `autoSaveBefore` in 1.18.0 causes required fields validation when it shouldn't (e.g. cancel operations) ([#368](https://github.com/tesler-platform/tesler-ui/issues/368))
 
 # Verson 1.18.1
 

--- a/src/middlewares/requiredFieldsMiddleware.ts
+++ b/src/middlewares/requiredFieldsMiddleware.ts
@@ -91,7 +91,7 @@ function operationRequiresAutosave(operationType: string, actions: Array<Operati
         console.error('rowMeta is missing in the middle of "sendOperation" action')
         return result
     }
-    result = flattenOperations(actions).some(action => action.autoSaveBefore)
+    result = flattenOperations(actions).some(action => action.type === operationType && action.autoSaveBefore)
     return result
 }
 


### PR DESCRIPTION
See #368 