### PR TITLE
MVG filter, dataItem keys.

### DIFF
--- a/src/components/ColumnTitle/ColumnFilter.tsx
+++ b/src/components/ColumnTitle/ColumnFilter.tsx
@@ -97,7 +97,7 @@ export const ColumnFilter: React.FC<ColumnFilterProps> = (props) => {
         onVisibleChange={handleVisibleChange}
     >
         <div
-            className={cn(styles.icon, { [styles.active]: !!props.filter })}
+            className={cn(styles.icon, { [styles.active]: props.filter?.value?.toString()?.length > 0 })}
             dangerouslySetInnerHTML={{ __html: filterIcon }}
         />
     </Popover>

--- a/src/components/widgets/AssocListPopup/AssocListPopup.tsx
+++ b/src/components/widgets/AssocListPopup/AssocListPopup.tsx
@@ -101,7 +101,6 @@ export const AssocListPopup: FunctionComponent<IAssocListProps & IAssocListActio
 
     const filterData = React.useCallback(() => {
         const filterValue = selectedRecords
-        .filter(item => item._associate)
         .map(item => item.id)
 
         onFilter(props.calleeBCName, {
@@ -211,13 +210,25 @@ function mapStateToProps(store: Store, ownProps: IAssocListOwnProps) {
     const bc = store.screen.bo.bc[bcName]
     const isFilter = store.view.popupData.isFilter
     const calleeBCName = store.view.popupData.calleeBCName
+    const associateFieldKey = store.view.popupData.associateFieldKey
+    const data = store.data[bcName] || emptyData
+    const bcFilters = store.screen.filters?.[calleeBCName]
+    const filterDataItems = bcFilters?.find(filterItem => filterItem.fieldName === associateFieldKey)?.value as DataItem[]
+    if (isFilter && filterDataItems?.length > 0) {
+        data?.forEach(dataItem => {
+            if (filterDataItems.includes(dataItem.id as unknown as DataItem)) {
+                dataItem._associate = true
+            }
+        })
+    }
+
     return {
         showed: store.view.popupData.bcName === bcName,
         assocValueKey: store.view.popupData.assocValueKey,
-        associateFieldKey: store.view.popupData.associateFieldKey,
+        associateFieldKey: associateFieldKey,
         bcLoading: bc?.loading,
         pendingDataChanges: store.view.pendingDataChanges[bcName],
-        data: store.data[bcName] || emptyData,
+        data: data,
         isFilter,
         calleeBCName
     }


### PR DESCRIPTION
MVG filter, dataItem keys (#371).

This filter of values ​​is not needed, because if `dataItems` ​​are present in `selectedRecords`, then they are selected for the filter values.