### PR TITLE
Custom action autosave

### DIFF
--- a/src/interfaces/operation.ts
+++ b/src/interfaces/operation.ts
@@ -309,13 +309,14 @@ export interface AssociatedItem extends DataItem {
 }
 
 /**
- * Дескриптор включения операции на виджете:
- * - либо строка (если надо просто включить/исключить операцию или группы)
- * - либо объект, если это группа в которой нужно выборочно включить или исключить операцию
+ * Descriptor enabling operation on widget:
+ * - string (if you just need to include / exclude operation or groups)
+ * - object, if this is group in which you want to selectively include or exclude the operation
  * 
- * @param type Тип операции; строка, уникально идентифицирующая операцию на виджете
- * @param include Список включаемых операций
- * @param exclude Список исключаемых операций
+ * @param type Type of transaction; a string that uniquely identifies the operation on the widget
+ * @param include List of included operations or groups operations
+ * @param exclude List of excluded operations or groups operations
+ * @param defaultSave default no crud save action
  */
 export type OperationInclusionDescriptor = string | {
     type: OperationType,

--- a/src/interfaces/widget.ts
+++ b/src/interfaces/widget.ts
@@ -300,14 +300,16 @@ export interface WidgetTextMeta extends WidgetMeta {
 }
 
 /**
- * Описание операций в опциях меты виджета, через который можно настраивать их доступность
+ * Description of operations in the widget meta options, through which you can configure their availability
  *
- * @param include Список включаемых операций или групп операций
- * @param exclude Список исключаемых операций или групп операций
+ * @param include List of included operations or groups operations
+ * @param exclude List of excluded operations or groups operations
+ * @param defaultSave default no crud save action
  */
 export interface WidgetOperations {
     include?: OperationInclusionDescriptor[],
-    exclude?: OperationType[]
+    exclude?: OperationType[],
+    defaultSave?: string
 }
 
 export type CustomWidget = ConnectedComponent<any, any> | FunctionComponent<any>

--- a/src/middlewares/autosaveMiddleware.ts
+++ b/src/middlewares/autosaveMiddleware.ts
@@ -21,6 +21,32 @@ const saveFormMiddleware = ({ getState, dispatch }: MiddlewareAPI<Dispatch<AnyAc
             const needToSaveTableChanges = isSendOperation && isAnotherBc
             const selectedCell = state.view.selectedCell
             const isSelectTableCellInit = action.type === types.selectTableCellInit
+
+
+            /**
+             * Default save operation as custom action
+             *
+             * If widget have only custom actions, `defaultSave` option mean witch action
+             * must be executed as save record.
+             * Current changeLocation action as onSuccessAction
+             */
+            const defaultSaveWidget = state.view.widgets?.find(item => item?.options?.actionGroups?.defaultSave)
+            const defaultCursor = state.screen.bo.bc?.[defaultSaveWidget?.bcName]?.cursor
+            const pendingData = state.view?.pendingDataChanges?.[defaultSaveWidget?.bcName]?.[defaultCursor]
+            if (defaultSaveWidget && action.type === types.changeLocation && pendingData) {
+                return next($do.sendOperation({
+                    bcName: defaultSaveWidget.bcName,
+                    operationType: defaultSaveWidget.options.actionGroups.defaultSave,
+                    widgetName: defaultSaveWidget.name,
+                    onSuccessAction: action
+                }))
+            }
+
+            /**
+             * Default save operation CRUD
+             *
+             */
+
             if (selectedCell
                 && (
                     needToSaveTableChanges


### PR DESCRIPTION
Custom action autosave (#387)

**Feature:** Autosave pending data by custon widget save action.

New ability to autosave by custom action on form widgets when have only custom actions. Required when user has input form and initiated drilldown.

New widget meta param `defaultSave` is name default no crud save action
_**Example:**_
``` ts
  "name": "Widget Name",
  "title": "Widget Title",
  "type": "Form",
  "bc": "bcName",
  ...
  "options": {
    "actionGroups": {
      "include": [
        "custom-save",
        "custom-cancel"
      ],
      "exclude": [
        "custom-edit",
      ],
      "defaultSave": "custom-save"
    },
   ...
  },
  }
```
When user input part or full Form and initial any `drillDown`, action `"defaultSave": "custom-save"` will be executed. But if custom save action `"defaultSave": "custom-save"` have `postAction` `drillDown`, then `postAction` not be perfomed, execute only user `drillDown`.