### PR TITLE
AssocListPopup Tag

### DIFF
--- a/src/components/widgets/AssocListPopup/AssocListPopup.tsx
+++ b/src/components/widgets/AssocListPopup/AssocListPopup.tsx
@@ -125,18 +125,19 @@ export const AssocListPopup: FunctionComponent<IAssocListProps & IAssocListActio
 
     // Tag values limit
     const tagLimit = 5
-    const visibleTags = selectedRecords.slice(0, tagLimit).map(item => ({
+    const assocTag = pendingDataChanges && Object.values(pendingDataChanges).filter(item => item._associate) || []
+    const visibleTags = assocTag.map(item => ({
         ...item,
         _value: String(item[props.assocValueKey] || ''),
         _closable: true
-    }))
-    const hiddenTagsCount = visibleTags.length - tagLimit
-    const tags: AssociatedItemTag[] = visibleTags.length > tagLimit
+    })).slice(0, tagLimit)
+    const hiddenTagsCount = assocTag.length - tagLimit
+    const tags: AssociatedItemTag[] = assocTag.length > tagLimit
         ? [
             ...visibleTags,
             { id: 'control', _associate: false, _value: `... ${hiddenTagsCount}` }
         ]
-        : selectedRecords.map(item => ({ ...item, _value: String(item[props.assocValueKey] || ''), _closable: true }))
+        : assocTag.map(item => ({ ...item, _value: String(item[props.assocValueKey] || ''), _closable: true }))
 
     const defaultTitle = tags.length
         ? <div>


### PR DESCRIPTION
AssocListPopup Tag broken (#393)

If `AssocListPopup` have many records and page pagination active, when showed `Tag` items only from current page. And cannot show `Tag` hidden counter because limit dataitems = tag limit as default. `Tag` dataitems match from current page data filtered by `pendingDataChanges` by function `useAssocRecords` and used only dataitems of current page.  

Change match `Tag` items from `pendingDataChanges` with `_associate` flag.