### PR TITLE
Support for default filters

### DIFF
--- a/src/interfaces/bc.ts
+++ b/src/interfaces/bc.ts
@@ -1,31 +1,50 @@
 /**
- * Интерфейсы для Business Component'ы
+ * Interfaces for Business Component
  */
 
 import {FilterGroup} from './filters'
 
- /**
-  * Meta data for Business Component
-  * 
-  * @param name Name of Business Component
-  * @param parentName Name of parent Business Component
-  * @param url TODO: desc, example
-  * @param cursor Currently active record
-  * @param defaultSort String representation of default bc sorters
-  *     "_sort.{order}.{direction}={fieldKey}&_sort.{order}.{direction}"
-  *     @param fieldKey Sort by field
-  *     @param order Priority of this specfic sorter
-  *     @param direction "asc" or "desc"
-  *     i.e. "_sort.0.asc=firstName"
-  * @param filterGroups Predefined filters
-  */
+/**
+ * Meta data for Business Component
+ */
 export interface BcMeta {
+    /**
+     * Name of Business Component
+     */
     name: string
+    /**
+     * Name of parent Business Component
+     */
     parentName: string | null
+    /**
+     * TODO: desc, example
+     */
     url: string,
+    /**
+     * Currently active record
+     */
     cursor: string | null,
+    /**
+     * String representation of default bc sorters
+     *     "_sort.{order}.{direction}={fieldKey}&_sort.{order}.{direction}"
+     *     @param fieldKey Sort by field
+     *     @param order Priority of this specific sorter
+     *     @param direction "asc" or "desc"
+     *     i.e. "_sort.0.asc=firstName"
+     */
     defaultSort?: string,
-    filterGroups?: FilterGroup[]
+    /**
+     * Predefined filters
+     */
+    filterGroups?: FilterGroup[],
+    /**
+     * String representation of default bc filters
+     *     "{fieldKey}.contains={someValue}"
+     *     @param fieldKey Filtering field
+     *     @param someValue Filter value
+     *     i.e. "someField1.contains=someValue&someField2.equalsOneOf=%5B%22someValue1%22%2C%22someValue2%22%5D"
+     */
+    defaultFilter?: string
 }
 
 export interface BcMetaState extends BcMeta {

--- a/src/reducers/screen.ts
+++ b/src/reducers/screen.ts
@@ -2,8 +2,8 @@ import {AnyAction, types} from '../actions/actions'
 import {ScreenState} from '../interfaces/screen'
 import {BcMeta, BcMetaState} from '../interfaces/bc'
 import {OperationTypeCrud} from '../interfaces/operation'
-import {parseSorters} from '../utils/filters'
-import {BcSorter} from '../interfaces/filters'
+import {parseFilters, parseSorters} from '../utils/filters'
+import {BcFilter, BcSorter} from '../interfaces/filters'
 
 const initialState: ScreenState = {
     screenName: null,
@@ -32,11 +32,16 @@ export function screen(state = initialState, action: AnyAction): ScreenState {
         case types.selectScreen: {
             const bcDictionary: Record<string, BcMeta> = {}
             const bcSorters: Record<string, BcSorter[]> = {}
+            const bcFilters: Record<string, BcFilter[]> = {}
             action.payload.screen.meta.bo.bc.forEach(item => {
                 bcDictionary[item.name] = item
                 const sorter = parseSorters(item.defaultSort)
+                const filter = parseFilters(item.defaultFilter)
                 if (sorter) {
                     bcSorters[item.name] = sorter
+                }
+                if (filter) {
+                    bcFilters[item.name] = filter
                 }
             })
             return {
@@ -45,7 +50,8 @@ export function screen(state = initialState, action: AnyAction): ScreenState {
                 primaryView: action.payload.screen.meta.primary,
                 views: action.payload.screen.meta.views,
                 bo: { activeBcName: null, bc: bcDictionary },
-                sorters: { ...state.sorters, ...bcSorters }
+                sorters: { ...state.sorters, ...bcSorters },
+                filters: { ...state.filters, ...bcFilters}
             }
         }
         case types.selectScreenFail: {


### PR DESCRIPTION
Added new string param in BcMeta: `defaultFilter`.
Example of `defaultFilter` value: 
'someField1.contains=someValue
&someField2.equalsOneOf=%5B%22someValue1%22%2C%22someValue2%22%5D'
See #399