### PR TITLE
FullHierarchy search enhancement

### DIFF
--- a/src/components/FilterPopup/FilterPopup.tsx
+++ b/src/components/FilterPopup/FilterPopup.tsx
@@ -67,7 +67,10 @@ export const FilterPopup: React.FC<FilterPopupProps> = (props) => {
         } else {
             dispatch($do.bcAddFilter({ bcName: widget.bcName, filter: newFilter }))
         }
-        dispatch($do.bcForceUpdate({ bcName: widget.bcName }))
+        // FullHierarchy has its own implementation of data search without backend query filtered data
+        if (!widget.options?.hierarchyFull) {
+            dispatch($do.bcForceUpdate({ bcName: widget.bcName }))
+        }
         props.onApply?.()
     }
 
@@ -75,7 +78,9 @@ export const FilterPopup: React.FC<FilterPopupProps> = (props) => {
         e.preventDefault()
         if (filter) {
             dispatch($do.bcRemoveFilter({ bcName: widget.bcName, filter }))
-            dispatch($do.bcForceUpdate({ bcName: widget.bcName }))
+            if (!widget.options?.hierarchyFull) {
+                dispatch($do.bcForceUpdate({ bcName: widget.bcName }))
+            }
         }
         props.onCancel?.()
     }

--- a/src/components/FullHierarchyTable/FullHierarchyTable.tsx
+++ b/src/components/FullHierarchyTable/FullHierarchyTable.tsx
@@ -84,7 +84,12 @@ export const FullHierarchyTable: React.FunctionComponent<FullHierarchyTableAllPr
             [FilterType.contains, FilterType.equals].includes(filter.type)),
         [props.bcFilters]
     )
-    const [filteredData, searchedAncestorsKeys] = useHierarchyCache(props.meta.name, textFilters, props.data, props.depth)
+    const [filteredData, searchedAncestorsKeys] = useHierarchyCache(
+        props.meta.name,
+        textFilters,
+        props.data,
+        props.depth,
+        props.meta.options?.hierarchyDisableDescendants)
 
     const data = (props?.nestedData?.length > 0 && depthLevel > 1)
         ? props.nestedData
@@ -96,7 +101,7 @@ export const FullHierarchyTable: React.FunctionComponent<FullHierarchyTableAllPr
 
     const [expandedKeys, setExpandedKeys] = useExpandedKeys(
         props.expandedRowKeys, selectedRecords, filteredData,
-        textFilters, searchedAncestorsKeys
+        textFilters, searchedAncestorsKeys, props.meta.options?.hierarchyDisableDescendants
     )
 
     const handleExpand = (expanded: boolean, dataItem: DataItem) => {

--- a/src/components/FullHierarchyTable/utils/useExpandedKeys.ts
+++ b/src/components/FullHierarchyTable/utils/useExpandedKeys.ts
@@ -34,13 +34,15 @@ const emptyArray: string[] = []
  * @param data TODO
  * @param filters TODO
  * @param searchAncestorsKeys TODO
+ * @param hierarchyDisableDescendants Disable searched item descendants in fullHierarchy search
  */
 export function useExpandedKeys(
     defaultExpandedKeys: string[],
     selectedRecords: FullHierarchyDataItem[],
     data: FullHierarchyDataItem[],
     filters: BcFilter[],
-    searchAncestorsKeys: Set<string>
+    searchAncestorsKeys: Set<string>,
+    hierarchyDisableDescendants?: boolean
 ) {
     const [expandedKeys, setExpandedKeys] = React.useState<string[]>([])
     React.useEffect(() => {
@@ -80,7 +82,9 @@ export function useExpandedKeys(
             ...expandedKeys,
             ...searchResultBranches
         ])
-        setExpandedKeys(prev => [ ...prev, ...Array.from(distinctExpandedKeys) ])
+        hierarchyDisableDescendants
+            ? setExpandedKeys(Array.from(searchResultBranches))
+            : setExpandedKeys(prev => [ ...prev, ...Array.from(distinctExpandedKeys) ])
     }, [filters, data, searchAncestorsKeys])
     return [expandedKeys, setExpandedKeys] as const
 }

--- a/src/components/FullHierarchyTable/utils/useHierarchyCache.ts
+++ b/src/components/FullHierarchyTable/utils/useHierarchyCache.ts
@@ -30,8 +30,15 @@ const descendantsKeysCache = new HierarchySearchCache()
  * @param filters Filters (only text fields supported)
  * @param data Records
  * @param depthLevel Level of the hierarchy for which hook is called
+ * @param hierarchyDisableDescendants Disable searched item descendants in fullHierarchy search
  */
-export function useHierarchyCache(widgetName: string, filters: BcFilter[], data: FullHierarchyDataItem[], depthLevel: number) {
+export function useHierarchyCache(
+    widgetName: string,
+    filters: BcFilter[],
+    data: FullHierarchyDataItem[],
+    depthLevel: number,
+    hierarchyDisableDescendants?: boolean) {
+
     React.useEffect(() => {
         const clearSearchCache = () => {
             if (depthLevel === 1) {
@@ -61,7 +68,8 @@ export function useHierarchyCache(widgetName: string, filters: BcFilter[], data:
 
     const filteredData = React.useMemo(() => {
         return filters?.length
-            ? data.filter(item => searchedAncestorsKeys.has(item.id) || searchedDescendantsKeys.has(item.id))
+            ? data.filter(item => searchedAncestorsKeys.has(item.id)
+                || !hierarchyDisableDescendants && searchedDescendantsKeys.has(item.id))
             : data
     }, [searchedAncestorsKeys, searchedDescendantsKeys, data, filters])
     return [filteredData, searchedAncestorsKeys, searchedDescendantsKeys] as const

--- a/src/epics/data.ts
+++ b/src/epics/data.ts
@@ -105,6 +105,10 @@ const bcFetchDataEpic: Epic = (action$, store) => action$.ofType(
         return widget.bcName === bcName && widget.type === WidgetTypes.AssocListPopup
             && (widget.options?.hierarchy || widget.options?.hierarchySameBc || widget.options?.hierarchyFull)
     })
+    const fullHierarchyWidget = state.view.widgets.find((widget) => {
+        return widget.bcName === bcName && widget.type === WidgetTypes.AssocListPopup && widget.options?.hierarchyFull
+    })
+
     const sameBcHierarchyOptions = anyHierarchyWidget?.options?.hierarchySameBc && anyHierarchyWidget?.options
     const depthLevel = sameBcHierarchyOptions && (action.type === types.bcFetchDataRequest && action.payload.depth || 1)
 
@@ -122,10 +126,11 @@ const bcFetchDataEpic: Epic = (action$, store) => action$.ofType(
         })
     }
 
+    // Hierarchy widgets has own filter implementation
     const fetchParams: Record<string, any> = {
         _page: page,
         _limit: limit,
-        ...getFilters(filters),
+        ...getFilters(fullHierarchyWidget ? [] : filters),
         ...getSorters(sorters)
     }
 

--- a/src/interfaces/widget.ts
+++ b/src/interfaces/widget.ts
@@ -187,6 +187,10 @@ export interface WidgetOptions {
     hierarchyRadio?: boolean,
     hierarchyRadioAll?: boolean,
     hierarchyDisableRoot?: boolean,
+    /**
+     * Disable searched item descendants in fullHierarchy search
+     */
+    hierarchyDisableDescendants?: boolean,
     hierarchyDisableParent?: boolean,
     actionGroups?: WidgetOperations,
     /**


### PR DESCRIPTION
FullHierarchy search enhancement (#403).

**_Feature_**
New `FullHierarchy` widget meta option:
``` ts
hierarchyDisableDescendants?: boolean
```
Means that `FullHierarchy` search result should not include descendants of found elements.


**_Bug fix_**
`<FilterPopup>` component should not do `bcForceUpdate` when a filter is _applied_ or _cleared_ on a `FullHierarchy`.

**_Bug fix_**
Data epic did not transfer `filters` param for `FullHierarchy` backend query. `sorters` parameters unchanged.
