### PR TITLE
Alpha build version comparison was fixed

### DIFF
--- a/.github/workflows/build-alpha-from-pr.yml
+++ b/.github/workflows/build-alpha-from-pr.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Grep version fron NPM registry
         id: grep_version
         run: |
-          echo "##[set-output name=current_version;]$(yarn info @tesler-ui/core versions | grep -Eo "${{ env.PACKAGE_VERSION }}(-alpha[0-9]{1,})?" | sort -r | head -1 | xargs echo)"
+          echo "##[set-output name=current_version;]$(yarn info @tesler-ui/core versions | grep -Eo "${{ env.PACKAGE_VERSION }}(-alpha[0-9]{1,})?" | sort -Vr | head -1 | xargs echo)"
 
       - name: Bump release version
         id: bump_version


### PR DESCRIPTION
There was a bug in alpha build workflow while version comparison.
If list of versions is:
```
1.18.2-alpha0
1.18.2-alpha1
1.18.2-alpha10
1.18.2-alpha2
1.18.2-alpha3
1.18.2-alpha4
1.18.2-alpha5
1.18.2-alpha6
1.18.2-alpha7
1.18.2-alpha8
1.18.2-alpha9
1.18.2
```
Then result of command `sort -r` is:
```
1.18.2-alpha9
1.18.2-alpha8
1.18.2-alpha7
1.18.2-alpha6
1.18.2-alpha5
1.18.2-alpha4
1.18.2-alpha3
1.18.2-alpha2
1.18.2-alpha10
1.18.2-alpha1
1.18.2-alpha0
1.18.2
```

So this PR fix command to `sort -Vr`, which result is:
```
1.18.2-alpha10
1.18.2-alpha9
1.18.2-alpha8
1.18.2-alpha7
1.18.2-alpha6
1.18.2-alpha5
1.18.2-alpha4
1.18.2-alpha3
1.18.2-alpha2
1.18.2-alpha1
1.18.2-alpha0
1.18.2
```