### PR TITLE
MVG field empty filter

### DIFF
--- a/src/components/widgets/AssocListPopup/AssocListPopup.test.tsx
+++ b/src/components/widgets/AssocListPopup/AssocListPopup.test.tsx
@@ -38,7 +38,7 @@ describe('AssocListPopup test', () => {
     const actionProps: IAssocListActions = {
         onSave: jest.fn(),
         onFilter: jest.fn(),
-        removeFilter: jest.fn(),
+        onRemoveFilter: jest.fn(),
         onDeleteTag: jest.fn(),
         onCancel: jest.fn(),
         onClose: jest.fn(),

--- a/src/components/widgets/AssocListPopup/AssocListPopup.test.tsx
+++ b/src/components/widgets/AssocListPopup/AssocListPopup.test.tsx
@@ -38,6 +38,7 @@ describe('AssocListPopup test', () => {
     const actionProps: IAssocListActions = {
         onSave: jest.fn(),
         onFilter: jest.fn(),
+        removeFilter: jest.fn(),
         onDeleteTag: jest.fn(),
         onCancel: jest.fn(),
         onClose: jest.fn(),

--- a/src/components/widgets/AssocListPopup/AssocListPopup.tsx
+++ b/src/components/widgets/AssocListPopup/AssocListPopup.tsx
@@ -27,9 +27,9 @@ export interface IAssocListRecord {
 export interface IAssocListActions {
     onSave: (bcNames: string[]) => void,
     onFilter: (bcName: string, filter: BcFilter) => void,
-    removeFilter: (bcName: string, filter: BcFilter) => void,
     onDeleteTag: (bcName: string, dataItem: DataItem) => void,
     onDeleteAssociations: (bcName: string, parentId: string, depth: number, assocValueKey: string, selected: boolean) => void,
+    onRemoveFilter?: (bcName: string, filter: BcFilter) => void,
     onCancel: () => void,
     onClose: () => void
 }
@@ -75,7 +75,7 @@ export const AssocListPopup: FunctionComponent<IAssocListProps & IAssocListActio
         onSave,
         bcFilters,
         onFilter,
-        removeFilter,
+        onRemoveFilter,
         onDeleteTag,
 
         width,
@@ -116,7 +116,7 @@ export const AssocListPopup: FunctionComponent<IAssocListProps & IAssocListActio
         } else {
             const currentFilters = bcFilters?.find(filterItem => filterItem.fieldName === props.associateFieldKey)?.value
             currentFilters
-            ? removeFilter(props.calleeBCName, {
+            ? onRemoveFilter?.(props.calleeBCName, {
                 type: FilterType.equalsOneOf,
                 fieldName: props.associateFieldKey,
                 value: currentFilters
@@ -124,7 +124,7 @@ export const AssocListPopup: FunctionComponent<IAssocListProps & IAssocListActio
             : $do.emptyAction(null)
         }
         onClose()
-    }, [onFilter, removeFilter, bcFilters, onClose, props.calleeBCName, props.associateFieldKey, selectedRecords])
+    }, [onFilter, onRemoveFilter, bcFilters, onClose, props.calleeBCName, props.associateFieldKey, selectedRecords])
 
     const cancelData = React.useCallback(() => {
         onCancel()
@@ -290,7 +290,7 @@ const mapDispatchToProps = createMapDispatchToProps(
                 ctx.dispatch($do.bcAddFilter({ bcName, filter }))
                 ctx.dispatch($do.bcForceUpdate({ bcName }))
             },
-            removeFilter: (bcName: string, filter: BcFilter) => {
+            onRemoveFilter: (bcName: string, filter: BcFilter) => {
                 ctx.dispatch($do.bcRemoveFilter({ bcName, filter }))
                 ctx.dispatch($do.bcForceUpdate({ bcName }))
             },

--- a/src/components/widgets/AssocListPopup/AssocListPopup.tsx
+++ b/src/components/widgets/AssocListPopup/AssocListPopup.tsx
@@ -27,6 +27,7 @@ export interface IAssocListRecord {
 export interface IAssocListActions {
     onSave: (bcNames: string[]) => void,
     onFilter: (bcName: string, filter: BcFilter) => void,
+    removeFilter: (bcName: string, filter: BcFilter) => void,
     onDeleteTag: (bcName: string, dataItem: DataItem) => void,
     onDeleteAssociations: (bcName: string, parentId: string, depth: number, assocValueKey: string, selected: boolean) => void,
     onCancel: () => void,
@@ -51,6 +52,7 @@ export interface IAssocListProps extends IAssocListOwnProps {
         [cursor: string]: PendingDataItem
     },
     data?: AssociatedItem[],
+    bcFilters?: BcFilter[],
     isFilter?: boolean,
     calleeBCName?: string
 }
@@ -71,7 +73,9 @@ export const AssocListPopup: FunctionComponent<IAssocListProps & IAssocListActio
         onCancel,
         onClose,
         onSave,
+        bcFilters,
         onFilter,
+        removeFilter,
         onDeleteTag,
 
         width,
@@ -103,14 +107,24 @@ export const AssocListPopup: FunctionComponent<IAssocListProps & IAssocListActio
     const filterData = React.useCallback(() => {
         const filterValue = selectedRecords
         .map(item => item.id)
-
-        onFilter(props.calleeBCName, {
-            type: FilterType.equalsOneOf,
-            fieldName: props.associateFieldKey,
-            value: filterValue
-        })
+        if (filterValue.length > 0) {
+            onFilter(props.calleeBCName, {
+                type: FilterType.equalsOneOf,
+                fieldName: props.associateFieldKey,
+                value: filterValue
+            })
+        } else {
+            const currentFilters = bcFilters?.find(filterItem => filterItem.fieldName === props.associateFieldKey)?.value
+            currentFilters
+            ? removeFilter(props.calleeBCName, {
+                type: FilterType.equalsOneOf,
+                fieldName: props.associateFieldKey,
+                value: currentFilters
+            })
+            : $do.emptyAction(null)
+        }
         onClose()
-    }, [onFilter, onClose, props.calleeBCName, props.associateFieldKey, selectedRecords])
+    }, [onFilter, removeFilter, bcFilters, onClose, props.calleeBCName, props.associateFieldKey, selectedRecords])
 
     const cancelData = React.useCallback(() => {
         onCancel()
@@ -233,6 +247,7 @@ function mapStateToProps(store: Store, ownProps: IAssocListOwnProps) {
         bcLoading: bc?.loading,
         pendingDataChanges: store.view.pendingDataChanges[bcName],
         data: data,
+        bcFilters,
         isFilter,
         calleeBCName
     }
@@ -273,6 +288,10 @@ const mapDispatchToProps = createMapDispatchToProps(
             },
             onFilter: (bcName: string, filter: BcFilter) => {
                 ctx.dispatch($do.bcAddFilter({ bcName, filter }))
+                ctx.dispatch($do.bcForceUpdate({ bcName }))
+            },
+            removeFilter: (bcName: string, filter: BcFilter) => {
+                ctx.dispatch($do.bcRemoveFilter({ bcName, filter }))
                 ctx.dispatch($do.bcForceUpdate({ bcName }))
             },
             onDeleteTag: (

--- a/src/epics/view.ts
+++ b/src/epics/view.ts
@@ -303,16 +303,6 @@ const showAssocPopup: Epic = (action$, store) => action$.ofType(types.showViewPo
                 }
             })
         }
-    } else {
-        const assocDataValues = state.data[bcName].filter(dataItem => dataItem._associate)
-        assocDataValues.forEach((record) => {
-            popupInitPendingChanges[record.id] = {
-                ...record,
-                id: record.id,
-                _associate: true,
-                _value: record[action.payload.assocValueKey]
-            }
-        })
     }
     return Observable.of($do.changeDataItems({
         bcName,


### PR DESCRIPTION
See  (#418).

Add processing empty filter values MVG fields. Empty MVG field filter value should not be stored. Empty value means that the filter for this field should be cleared if exist current filter values for this field.

Removed pending data view update in favor of the `useAssocRecords` utility. (Bug when open popup after delete filter - show previos data assoc. Reopen popup without assoc.)