### PR TITLE
Custom autosave bugfix

### DIFF
--- a/src/epics/screen.ts
+++ b/src/epics/screen.ts
@@ -18,11 +18,17 @@ const processPostInvoke: Epic = (action$, store) => action$.ofType(types.process
     const state = store.getState()
     switch (action.payload.postInvoke.type) {
         case OperationPostInvokeType.drillDown:
-            return Observable.of($do.drillDown({
+            return Observable.concat(
+                /**
+                 * Cancel pending changes before postAction drillDown.
+                 * Allows exclude execute custom autoSave.
+                 */
+            Observable.of($do.bcCancelPendingChanges({bcNames: [action.payload.bcName]})),
+            Observable.of($do.drillDown({
                 ...action.payload.postInvoke as OperationPostInvokeDrillDown,
                 route: state.router,
                 widgetName: action.payload.widgetName
-            }))
+            })))
         case OperationPostInvokeType.postDelete: {
             const cursorsMap: ObjectMap<string> = { [action.payload.bcName]: null }
             const result: AnyAction[] = [$do.bcChangeCursors({ cursorsMap })]

--- a/src/middlewares/autosaveMiddleware.ts
+++ b/src/middlewares/autosaveMiddleware.ts
@@ -33,7 +33,7 @@ const saveFormMiddleware = ({ getState, dispatch }: MiddlewareAPI<Dispatch<AnyAc
             const defaultSaveWidget = state.view.widgets?.find(item => item?.options?.actionGroups?.defaultSave)
             const defaultCursor = state.screen.bo.bc?.[defaultSaveWidget?.bcName]?.cursor
             const pendingData = state.view?.pendingDataChanges?.[defaultSaveWidget?.bcName]?.[defaultCursor]
-            if (defaultSaveWidget && action.type === types.changeLocation && pendingData) {
+            if (defaultSaveWidget && action.type === types.changeLocation && pendingData && Object.keys(pendingData).length) {
                 return next($do.sendOperation({
                     bcName: defaultSaveWidget.bcName,
                     operationType: defaultSaveWidget.options.actionGroups.defaultSave,


### PR DESCRIPTION
See #434 

Bugfix custom autosave:
1. Check `pendingData` as not empty object with `Object.keys(pendingData).length` function
2. Execute `bcCancelPendingChanges` action before `drillDown` `postAction`.  This will clear `pendingData` before `changeLocation`. So custom autosave not perform, if exist.