### PR TITLE
`pendingValidationFails` are divided by BC names and cursors (#441)

### DIFF
--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -5,7 +5,7 @@ import {Form, Icon, Input, Tooltip} from 'antd'
 import {$do} from '../../actions/actions'
 import {Store} from '../../interfaces/store'
 import {DataItem, DataValue, MultivalueSingleValue, PendingDataItem} from '../../interfaces/data'
-import {FieldType} from '../../interfaces/view'
+import {FieldType, PendingValidationFails, PendingValidationFailsFormat} from '../../interfaces/view'
 import {RowMetaField} from '../../interfaces/rowMeta'
 import {WidgetField, WidgetTypes} from '../../interfaces/widget'
 import DatePickerField from '../ui/DatePickerField/DatePickerField'
@@ -409,7 +409,10 @@ function mapStateToProps(store: Store, ownProps: FieldOwnProps) {
     const bcUrl = buildBcUrl(ownProps.bcName, true)
     const rowMeta = bcUrl && store.view.rowMeta[ownProps.bcName]?.[bcUrl]
     const rowFieldMeta = rowMeta?.fields.find(field => field.key === ownProps.widgetFieldMeta.key)
-    const missing = store.view.pendingValidationFails?.[ownProps.widgetFieldMeta.key]
+    const missing = store.view.pendingValidationFailsFormat === PendingValidationFailsFormat.target
+        ? (store.view.pendingValidationFails as PendingValidationFails)
+            ?.[ownProps.bcName]?.[ownProps.cursor]?.[ownProps.widgetFieldMeta.key]
+        : store.view.pendingValidationFails?.[ownProps.widgetFieldMeta.key]
     const metaError = missing || rowMeta?.errors?.[ownProps.widgetFieldMeta.key]
     const pendingValue = store.view.pendingDataChanges[ownProps.bcName]
     ?.[ownProps.cursor]

--- a/src/components/widgets/FormWidget/FormWidget.tsx
+++ b/src/components/widgets/FormWidget/FormWidget.tsx
@@ -9,7 +9,7 @@ import Field from '../../Field/Field'
 import {useFlatFormFields} from '../../../hooks/useFlatFormFields'
 import styles from './FormWidget.less'
 import cn from 'classnames'
-import {FieldType} from '../../../interfaces/view'
+import {FieldType, PendingValidationFails, PendingValidationFailsFormat} from '../../../interfaces/view'
 import TemplatedTitle from '../../TemplatedTitle/TemplatedTitle'
 
 interface FormWidgetOwnProps {
@@ -92,8 +92,10 @@ function mapStateToProps(store: Store, ownProps: FormWidgetOwnProps) {
     const rowMeta = bcUrl && store.view.rowMeta[bcName]?.[bcUrl]
     const fields = rowMeta?.fields
     const metaErrors = rowMeta?.errors
-    const missingFields = store.view.pendingValidationFails
     const cursor = bc?.cursor
+    const missingFields = store.view.pendingValidationFailsFormat === PendingValidationFailsFormat.target
+        ? (store.view.pendingValidationFails as PendingValidationFails)?.[bcName]?.[cursor]
+        : store.view.pendingValidationFails
     return {
         cursor,
         fields,

--- a/src/interfaces/view.ts
+++ b/src/interfaces/view.ts
@@ -10,6 +10,21 @@ export interface ViewSelectedCell {
     fieldKey: string
 }
 
+export interface PendingValidationFails {
+    [bcName: string]: {
+        [cursor: string]: Record<string, string>
+    }
+}
+
+/**
+ * Describes format of `pendingValidationFails`
+ * TODO remove in 2.0.0
+ */
+export const enum PendingValidationFailsFormat {
+    old = 'old',
+    target = 'target'
+}
+
 export interface ViewState extends ViewMetaResponse {
     rowMeta: {
         [bcName: string]: {
@@ -35,7 +50,15 @@ export interface ViewState extends ViewMetaResponse {
     selectedCell?: ViewSelectedCell,
     systemNotifications?: SystemNotification[],
     error?: ApplicationError,
-    pendingValidationFails?: Record<string, string>,
+    /**
+     * For backward compatibility
+     *
+     * `old` describes `pendingValidationFails` as `Record<string, string>`
+     * `target` describes `pendingValidationFails` as `PendingValidationFails`
+     */
+    pendingValidationFailsFormat?: PendingValidationFailsFormat.old | PendingValidationFailsFormat.target, // TODO remove in 2.0.0
+    // TODO 2.0.0: should be `pendingValidationFails?: PendingValidationFails`
+    pendingValidationFails?: Record<string, string> | PendingValidationFails,
     modalInvoke?: {
         operation: {
             bcName: string,

--- a/src/middlewares/__tests__/requireFieldsMiddleware.ts
+++ b/src/middlewares/__tests__/requireFieldsMiddleware.ts
@@ -1,0 +1,103 @@
+import {hasPendingValidationFails} from '../requiredFieldsMiddleware'
+import {mockStore} from '../../tests/mockStore'
+import {PendingValidationFailsFormat} from '../../interfaces/view'
+
+let initStore = mockStore().getState()
+initStore = {
+    ...initStore,
+    bo: {
+        ...initStore.bo,
+        bc: {
+            test: {
+            }
+        }
+    }
+}
+const bcName = Object.keys(initStore.screen.bo.bc)[0]
+describe('hasPendingValidationFails target format test', () => {
+    it('1. should return `false`', () =>  {
+        expect(hasPendingValidationFails(initStore, bcName)).toBeFalsy()
+    })
+    it('2. should return `false`', () =>  {
+        const store = {
+            ...initStore,
+            view: {
+                ...initStore.view,
+                pendingValidationFailsFormat: PendingValidationFailsFormat.target,
+                pendingValidationFails: {
+                    [bcName]: {}
+                }
+            }
+        }
+        expect(hasPendingValidationFails(store, bcName)).toBeFalsy()
+    })
+    it('3. should return `false`', () =>  {
+        const store = {
+            ...initStore,
+            view: {
+                ...initStore.view,
+                pendingValidationFailsFormat: PendingValidationFailsFormat.target,
+                pendingValidationFails: {
+                    [bcName]: {
+                        '1000': {}
+                    }
+                }
+            }
+        }
+        expect(hasPendingValidationFails(store, bcName)).toBeFalsy()
+    })
+    it('1. should return `true`', () =>  {
+        const store = {
+            ...initStore,
+            view: {
+                ...initStore.view,
+                pendingValidationFailsFormat: PendingValidationFailsFormat.target,
+                pendingValidationFails: {
+                    [bcName]: {
+                        '1000': {
+                            aa: 'aaa'
+                        }
+                    }
+                }
+            }
+        }
+        expect(hasPendingValidationFails(store, bcName)).toBeTruthy()
+    })
+    it('2. should return `true`', () =>  {
+        const store = {
+            ...initStore,
+            view: {
+                ...initStore.view,
+                pendingValidationFailsFormat: PendingValidationFailsFormat.target,
+                pendingValidationFails: {
+                    'anotherBc': {},
+                    [bcName]: {
+                        '10001': {},
+                        '1000': {
+                            aa: 'aaa'
+                        }
+                    }
+                }
+            }
+        }
+        expect(hasPendingValidationFails(store, bcName)).toBeTruthy()
+    })
+})
+
+describe('hasPendingValidationFails old format test' , () => {
+    it('should return `false`', () =>  {
+        expect(hasPendingValidationFails(initStore, bcName)).toBeFalsy()
+    })
+    it('should return `true`', () =>  {
+        const store = {
+            ...initStore,
+            view: {
+                ...initStore.view,
+                pendingValidationFails: {
+                    aaa: 'aaa'
+                }
+            }
+        }
+        expect(hasPendingValidationFails(store, bcName)).toBeTruthy()
+    })
+})


### PR DESCRIPTION
See #441 

A target form of the interface of `pendingValidationFails` is looks like:
```
    pendingValidationFails?: PendingValidationFails
```
where `PendingValidationFails` is:
```
interface PendingValidationFails {
    [bcName: string]: {
        [cursor: string]: Record<string, string>
    }
}

```

### Backward compatibility
I provide temporary solution for backward compatibility until `2.0.0` release will be released.
Temporary interface for `pendingValidationFails` looks like this:
```
pendingValidationFails?: Record<string, string> | PendingValidationFails,
```  
I've added `pendingValidationFailsFormat` as flag of `target` or `old` formats of `pendingValidationFails`.
Currently, if you'd like to use target version of `pendingValidationFails`, you can simply set
```pendingValidationFailsFormat: PendingValidationFailsFormat.target``` in initial state of overriding of `view` reducer.