### PR TITLE
hierarchyTraverse diselect bugfix. MVG field hierarchy behavior.

### DIFF
--- a/src/components/ui/Multivalue/MultivalueTag.tsx
+++ b/src/components/ui/Multivalue/MultivalueTag.tsx
@@ -54,7 +54,7 @@ const MultivalueTag: React.FunctionComponent<MultivalueTagProps> = (props) => {
                     return <Tag
                         onClick={(e) => {e.stopPropagation()}}
                         title={val.value}
-                        closable={!props.disabled}
+                        closable={!props.disabled && !loading}
                         id={val.id}
                         key={val.id}
                         onClose={() => {

--- a/src/components/widgets/AssocListPopup/AssocListPopup.tsx
+++ b/src/components/widgets/AssocListPopup/AssocListPopup.tsx
@@ -27,7 +27,8 @@ export interface IAssocListRecord {
 export interface IAssocListActions {
     onSave: (bcNames: string[]) => void,
     onFilter: (bcName: string, filter: BcFilter) => void,
-    onDeleteTag: (bcName: string, dataItem: DataItem) => void,
+    onDeleteTag: (bcName: string, depth: number, widgetName: string,
+                  dataItem: AssociatedItem, assocValueKey: string) => void,
     onDeleteAssociations: (bcName: string, parentId: string, depth: number, assocValueKey: string, selected: boolean) => void,
     onRemoveFilter?: (bcName: string, filter: BcFilter) => void,
     onCancel: () => void,
@@ -131,12 +132,17 @@ export const AssocListPopup: FunctionComponent<IAssocListProps & IAssocListActio
     }, [onCancel, onClose])
 
     const handleDeleteTag = React.useCallback((val: DataItem) => {
-        if (!val._associate && props.widget.options.hierarchyGroupDeselection) {
-            props.onDeleteAssociations(props.widget.bcName, val.id, (val.level as number + 1), props.assocValueKey, false)
-        }
-        onDeleteTag(props.widget.bcName, val)
-    },
-        [props.onDeleteTag,props.widget.bcName,props.onDeleteAssociations]
+            if (props.widget.options?.hierarchyGroupDeselection) {
+                props.onDeleteAssociations(props.widget.bcName, val.id, (val.level as number + 1), props.assocValueKey, false)
+            }
+            props.onDeleteTag(props.widget.bcName, (val.level as number), props.widget.name,
+                {...val, _associate: false} as AssociatedItem, props.assocValueKey)
+        },
+        [props.onDeleteTag,
+            props.widget,
+            props.pendingDataChanges,
+            props.assocValueKey,
+            props.onDeleteAssociations]
     )
 
     // Tag values limit
@@ -281,8 +287,21 @@ const mapDispatchToProps = createMapDispatchToProps(
                     ctx.dispatch($do.bcCancelPendingChanges({bcNames: [ctx.props.bcName]}))
                 }
             },
-            onDeleteAssociations: (bcName: string, parentId: string, depth: number, assocValueKey: string, selected: boolean) => {
+            onDeleteAssociations: (bcName: string,parentId: string,depth: number,assocValueKey: string,selected: boolean) => {
                 ctx.dispatch($do.changeDescendantsAssociationsFull({ bcName, parentId, depth, assocValueKey, selected }))
+            },
+            onDeleteTag: (
+                bcName: string,
+                depth: number,
+                widgetName: string,
+                dataItem: AssociatedItem,
+                assocValueKey: string ) => {
+                ctx.dispatch($do.changeAssociationFull({
+                    bcName,
+                    depth,
+                    widgetName,
+                    dataItem,
+                    assocValueKey }))
             },
             onFilter: (bcName: string, filter: BcFilter) => {
                 ctx.dispatch($do.bcAddFilter({ bcName, filter }))
@@ -292,18 +311,6 @@ const mapDispatchToProps = createMapDispatchToProps(
                 ctx.dispatch($do.bcRemoveFilter({ bcName, filter }))
                 ctx.dispatch($do.bcForceUpdate({ bcName }))
             },
-            onDeleteTag: (
-                bcName: string,
-                val: AssociatedItem) => {
-                ctx.dispatch($do.changeDataItem({
-                    bcName,
-                    cursor: val.id,
-                    dataItem: {
-                        ...val,
-                        _associate: false,
-                    }
-                }))
-            }
         }
     }
 )

--- a/src/epics/data.ts
+++ b/src/epics/data.ts
@@ -642,13 +642,13 @@ const changeAssociation: Epic = (action$, store) => action$.ofType(types.changeA
     ]
     const widget = state.view.widgets.find(item => item.name === action.payload.widgetName) as WidgetTableMeta
     const isRoot = action.payload.bcName === widget.bcName
-    const rootHierarchyDescriptor = { bcName: widget.bcName, radio: widget.options.hierarchyRadio, fields: widget.fields }
-    const hierarchy = widget.options.hierarchy
+    const rootHierarchyDescriptor = { bcName: widget.bcName, radio: widget.options?.hierarchyRadio, fields: widget.fields }
+    const hierarchy = widget.options?.hierarchy
     const hierarchyDescriptor: WidgetTableHierarchy = isRoot
         ? rootHierarchyDescriptor
         : hierarchy.find(item => item.bcName === action.payload.bcName)
-    const hierarchyGroupSelection = widget.options.hierarchyGroupSelection
-    const hierarchyTraverse = widget.options.hierarchyTraverse
+    const hierarchyGroupSelection = widget.options?.hierarchyGroupSelection
+    const hierarchyTraverse = widget.options?.hierarchyTraverse
     const childrenBc = hierarchy
         .slice(hierarchy.findIndex(item => item.bcName === action.payload.bcName) + 1)
         .map(item => item.bcName)
@@ -724,7 +724,7 @@ const changeAssociationSameBc: Epic = (action$, store) => action$.ofType(types.c
     const depth = action.payload.depth || 1
     const parentDepth = depth - 1
     const widget = state.view.widgets.find(item => item.name === action.payload.widgetName) as WidgetTableMeta
-    const hierarchyTraverse = widget.options.hierarchyTraverse
+    const hierarchyTraverse = widget.options?.hierarchyTraverse
 
     const currentData = (depth > 1)
         ? state.depthData[depth]?.[bcName]
@@ -792,9 +792,9 @@ const changeAssociationFull: Epic = (action$, store) => action$.ofType(types.cha
     const parentDepth = depth - 1
     const parentItem = (depth > 1) && allData.find((item) => item.id === action.payload.dataItem.parentId)
     const widget = state.view.widgets.find(item => item.name === action.payload.widgetName) as WidgetTableMeta
-    const hierarchyTraverse = widget.options.hierarchyTraverse
-    const rootRadio = widget.options.hierarchyRadio
-    const hierarchyGroupDeselection = widget.options.hierarchyGroupDeselection
+    const hierarchyTraverse = widget.options?.hierarchyTraverse
+    const rootRadio = widget.options?.hierarchyRadio
+    const hierarchyGroupDeselection = widget.options?.hierarchyGroupDeselection
 
     const currentLevelData = allData.filter(
         (item) => item.level === depth && (item.level === 1 || (item.parentId === parentItem?.id))
@@ -856,10 +856,6 @@ const changeAssociationFull: Epic = (action$, store) => action$.ofType(types.cha
     }
 
     if (parentDepth && hierarchyTraverse && !selected) {
-        const wasLastInData = currentLevelData
-            .filter(item => item.id !== action.payload.dataItem.id)
-            .every(item => !item._associate)
-
         const delta = state.view.pendingDataChanges[bcName]
         const wasLastInDelta = !delta
             || !Object.values(delta).find((deltaValue) => {
@@ -868,6 +864,10 @@ const changeAssociationFull: Epic = (action$, store) => action$.ofType(types.cha
                     && currentLevelData.find((dataValue) => dataValue.id === deltaValue.id)
                 )
             })
+        const deltaFalseId = delta && Object.values(delta)?.filter(item => item._associate === false).map(item => item.id)
+        const wasLastInData = currentLevelData
+            .filter(item => item.id !== action.payload.dataItem.id && !deltaFalseId?.includes(item.id))
+            .every(item => !item._associate)
 
         if (wasLastInData && wasLastInDelta) {
             result.push(Observable.of($do.changeAssociationFull({
@@ -930,11 +930,11 @@ function requestBcChildren(bcName: string) {
         return hierarchy && (item.bcName === bcName || nestedBc.includes(bcName))
     }) as WidgetTableMeta
     if (hierarchyWidget) {
-        const nestedBcNames = hierarchyWidget.options.hierarchy.map(nestedItem => nestedItem.bcName)
+        const nestedBcNames = hierarchyWidget.options?.hierarchy.map(nestedItem => nestedItem.bcName)
         const childHierarchyBcIndex = nestedBcNames.findIndex(item => item === bcName)
         const childHierarchyBcName = childHierarchyBcIndex !== -1
             ? nestedBcNames[childHierarchyBcIndex + 1]
-            : hierarchyWidget.options.hierarchy[0].bcName
+            : hierarchyWidget.options?.hierarchy[0].bcName
         if (!childHierarchyBcName) {
             return childrenBcMap
         }
@@ -949,19 +949,24 @@ function requestBcChildren(bcName: string) {
 export const removeMultivalueTag: Epic = (action$, store) => action$.ofType(types.removeMultivalueTag)
 .mergeMap(action => {
     const state = store.getState()
-
-    const removedItemId = action.payload.removedItem.id
+    const result: Array<Observable<AnyAction>> = []
     let removedItemBc = action.payload.popupBcName
+    const popupFirstLevelDelta = state.view.pendingDataChanges[removedItemBc]
+    const widget = state.view.widgets.find((checkWidget) =>
+        checkWidget.bcName === action.payload.popupBcName && checkWidget.type === WidgetTypes.AssocListPopup
+    )
+    const allData = state?.data[removedItemBc] || []
+    const removeDataItem = allData?.find(item => item.id === action.payload.removedItem.id)
+    const deltaId = Object.values(state.view.pendingDataChanges
+        [action.payload.bcName]?.[action.payload.cursor]?.[action.payload.associateFieldKey] || {}).map(item => item.id)
+    const delta = allData.filter(item => deltaId?.includes(item.id))
+    const parentDepth = removeDataItem.level as number -1
 
-    const popupFirstLevelDelta = state.view.pendingDataChanges[action.payload.popupBcName]
-    if (!popupFirstLevelDelta || !popupFirstLevelDelta[removedItemId]) {
-        const widget = state.view.widgets.find((checkWidget) =>
-            checkWidget.bcName === action.payload.popupBcName && checkWidget.type === WidgetTypes.AssocListPopup
-        )
+    if (!popupFirstLevelDelta || !popupFirstLevelDelta[removeDataItem.id]) {
         if (widget?.options?.hierarchy) {
-            widget.options.hierarchy.some((hierarchyData) => {
+            widget.options?.hierarchy.some((hierarchyData) => {
                 const hierarchyDelta = state.view.pendingDataChanges[hierarchyData.bcName]
-                if (hierarchyDelta?.[removedItemId]) {
+                if (hierarchyDelta?.[removeDataItem.id]) {
                     removedItemBc = hierarchyData.bcName
                     return true
                 }
@@ -970,22 +975,69 @@ export const removeMultivalueTag: Epic = (action$, store) => action$.ofType(type
         }
     }
 
-    return Observable.concat(
-        Observable.of($do.changeDataItem({
-            bcName: removedItemBc,
-            cursor: removedItemId,
-            dataItem: {
-                ...(action.payload.removedItem as any),
-                _associate: false,
+    if (parentDepth && widget.options?.hierarchyTraverse) {
+        const parentItem = (removeDataItem.level > 1) && allData?.find((item) => item.id === removeDataItem.parentId)
+        const removedItem = action.payload.dataItem.find(item => item.id === parentItem.id)
+        const currentLevelData = allData?.filter(
+            (item) => item.level === removeDataItem?.level && (item.level === 1 || (item.parentId === removeDataItem?.parentId))
+        )
+        const currentLevelDelta = delta.filter(
+            (item) => item.level === removeDataItem?.level && (item.level === 1 || (item.parentId === removeDataItem?.parentId))
+        )
+        const wasLastInDelta = !currentLevelDelta
+            .filter(item => item.id !== removeDataItem.id)
+            .filter(item => item.level === removeDataItem.level).length
+        // delta include only associated items and contain associated dataItems
+        const wasLastInData = delta?.length > 0 || currentLevelData
+            .filter(item => item.id !== removeDataItem.id)
+            .every(item => item._associate === false)
+
+        if (removedItem && wasLastInData && wasLastInDelta) {
+            result.push(Observable.of($do.removeMultivalueTag({
+                bcName: action.payload.bcName,
+                popupBcName: action.payload.popupBcName,
+                cursor: action.payload.cursor,
+                associateFieldKey: action.payload.associateFieldKey,
+                dataItem: action.payload.dataItem.filter(item => item.id !== parentItem.id),
+                removedItem: removedItem
+            })))
+        }
+    }
+
+    if (widget.options?.hierarchyGroupDeselection) {
+        // delta include only associated items and contain associated dataItems
+        const currentData = delta.length > 0 ? [] : allData.filter(item => item._associate === true)
+        const currentDataItems = [...currentData, ...delta]
+        const childDataItems = currentDataItems.filter(item => item.parentId === removeDataItem.id)
+        const deleteItems: DataItem[] = []
+        while(childDataItems.length > 0){
+            const tempItem = childDataItems.shift()
+            deleteItems.push(tempItem)
+            const nextChild = currentDataItems.filter(item => item.parentId === tempItem.id)
+            if (nextChild.length){
+                nextChild.forEach(item => childDataItems.push(item))
             }
-        })),
+        }
+        if (deleteItems.length) {
+            result.push(Observable.of($do.changeDataItem({
+                bcName: action.payload.bcName,
+                cursor: action.payload.cursor,
+                dataItem: {
+                    [action.payload.associateFieldKey]: action.payload.dataItem
+                        .filter(item => !deleteItems.map(deleteItem => deleteItem.id).includes(item.id))
+                }
+            })))
+        }
+    }
+    return Observable.concat(
         Observable.of($do.changeDataItem({
             bcName: action.payload.bcName,
             cursor: action.payload.cursor,
             dataItem: {
                 [action.payload.associateFieldKey]: action.payload.dataItem
             }
-        }))
+        })),
+        ...result
     )
 })
 

--- a/src/epics/data/removeMultivalueTag.ts
+++ b/src/epics/data/removeMultivalueTag.ts
@@ -1,0 +1,164 @@
+/*
+ * TESLER-UI
+ * Copyright (C) 2018-2020 Tesler Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Observable} from 'rxjs'
+import {Store} from 'redux'
+import {Epic, types, $do, AnyAction, ActionsMap} from '../../actions/actions'
+import {PopupWidgetTypes} from '../../interfaces/widget'
+import {TreeAssociatedRecord} from '../../interfaces/tree'
+import {assignTreeLinks, getDescendants} from '../../utils/tree'
+import {Store as CoreStore} from '../../interfaces/store'
+
+/**
+ * For full hierarchies it fires `changeDataItem` action to remove value from source record
+ *
+ * With `hierarchyGroupDeselection` widget option, parent removal also remove children; removing
+ * last child will also remove the parent.
+ *
+ * With `hierarchyTraverse` widget option, descendants are used instead of children.
+ *
+ * When parent should be removed with both option, `removeMultivalueTag` with updated `removedItem` will
+ * fire instead of `changeDataItem`.
+ *
+ * For non-full hierarchies two `changeDataItem` actions will fire, first to drop `_associate` flag
+ * of remove item and second to update value of soure record.
+ * Widget options are not tested for non-full hierarchies.
+ *
+ * @param action removeMultivalueTag
+ * @param store Store instance
+ */
+export const removeMultivalueTag: Epic = (action$, store) => action$.ofType(types.removeMultivalueTag)
+.mergeMap(action => {
+    return removeMultivalueTagImpl(action, store)
+})
+
+/**
+ * Default implementation for `removeMultivalueTag` epic
+ *
+ * For full hierarchies it fires `changeDataItem` action to remove value from source record
+ *
+ * With `hierarchyGroupDeselection` widget option, parent removal also remove children; removing
+ * last child will also remove the parent.
+ *
+ * With `hierarchyTraverse` widget option, descendants are used instead of children.
+ *
+ * When parent should be removed with both option, `removeMultivalueTag` with updated `removedItem` will
+ * fire instead of `changeDataItem`.
+ *
+ * For non-full hierarchies two `changeDataItem` actions will fire, first to drop `_associate` flag
+ * of remove item and second to update value of soure record.
+ * Widget options are not tested for non-full hierarchies.
+ *
+ * @param action removeMultivalueTag
+ * @param store Store instance
+ */
+export function removeMultivalueTagImpl(action: ActionsMap['removeMultivalueTag'], store: Store<CoreStore, AnyAction>) {
+    const state = store.getState()
+    const {bcName, cursor, popupBcName, associateFieldKey} = action.payload
+    const widget = state.view.widgets.find(item =>
+        item.bcName === popupBcName && PopupWidgetTypes.includes(item.type as typeof PopupWidgetTypes[number])
+    )
+    const storeData = (state?.data[popupBcName] || []) as unknown as TreeAssociatedRecord[]
+    // Merge store data with pending changes
+    let data: TreeAssociatedRecord[] = storeData.map(item => {
+        const pendingChanges = state.view.pendingDataChanges[popupBcName]?.[item.id]
+        return ({ ...item, ...pendingChanges })
+    })
+    const removedItem = data.find(item => item.id === action.payload.removedItem.id)
+    /**
+     * It seems `_associate` is always false for full hierarchies
+     * so we rely on source record value instead
+     */
+    const associated = action.payload.dataItem.map(item => item.id)
+    let removedNodes: string[] = []
+    if (widget.options?.hierarchyGroupDeselection) {
+        // Builds a tree to simplify searching of descendants
+        if (widget.options?.hierarchyTraverse) {
+            data = assignTreeLinks(data)
+        }
+        const removedItemChildren = data.filter(item => item.parentId === removedItem.id)
+        removedNodes = [
+            removedItem.id,
+            ...removedItemChildren
+                .filter(item => associated.includes(item.id))
+                .map(item => item.id)
+        ]
+        if (widget.options?.hierarchyTraverse) {
+            getDescendants(removedItemChildren, removedNodes)
+            removedNodes = data
+                .filter(item => removedNodes.includes(item.id) && associated.includes(item.id))
+                .map(item => item.id)
+        }
+        const parent = data.find(item => item.id === removedItem.parentId)
+        const siblings = data.filter(item => item.parentId === parent?.id)
+        const parentEmpty = siblings.every(child => removedNodes.includes(child.id) || !associated.includes(child.id))
+        // If last child/descendant removed, parent also should be
+        if (parent && parentEmpty) {
+            // Last descendant
+            if (widget.options?.hierarchyTraverse) {
+                const parentDescendants: string[] = []
+                getDescendants(siblings, parentDescendants)
+                const parentDeepEmpty = parentDescendants.every(descendant => {
+                    return (removedNodes.includes(descendant) || !associated.includes(descendant))
+                })
+                if (parentDeepEmpty) {
+                    return Observable.concat(
+                        Observable.of($do.removeMultivalueTag({
+                            ...action.payload,
+                            removedItem: { id: parent.id, value: null }
+                        }))
+                    )
+                }
+            } else {
+                // Last child
+                removedNodes.push(parent.id)
+            }
+        }
+    }
+    // Full hierarchies just filter out selected records
+    if (widget.options?.hierarchyFull) {
+        return Observable.of($do.changeDataItem({
+            bcName,
+            cursor,
+            dataItem: { [associateFieldKey]: action.payload.dataItem.filter(item => !removedNodes.includes(item.id)) }
+        })) as Observable<AnyAction>
+    }
+    return Observable.concat(
+        // Non-full hierarches drops removed item's `_associate` flag`
+        Observable.of($do.changeDataItem({
+            /**
+             * This is incorrect and will break if different BC has records with
+             * identical ids.
+             *
+             * TODO: Record `level` should be mapped to hierarchyData index instead
+             */
+            bcName: widget.options.hierarchy.find(hierarchyData => {
+                    return state.view.pendingDataChanges[hierarchyData.bcName]
+                        ?.[action.payload.removedItem.id]
+                })
+                ?.bcName ?? bcName,
+            cursor: action.payload.removedItem.id,
+            dataItem: { ...action.payload.removedItem as any, _associate: false }
+        })),
+        // And also updates source record value
+        Observable.of($do.changeDataItem({
+            bcName,
+            cursor,
+            dataItem: { [associateFieldKey]: action.payload.dataItem }
+        }))
+    )
+}

--- a/src/epics/view.ts
+++ b/src/epics/view.ts
@@ -283,7 +283,7 @@ const showAssocPopup: Epic = (action$, store) => action$.ofType(types.showViewPo
     const state = store.getState()
 
     const assocWidget = state.view.widgets.find((widget) => widget.bcName === bcName && widget.type === WidgetTypes.AssocListPopup)
-    if (!assocWidget?.options?.hierarchyFull) {
+    if (assocWidget?.options && !assocWidget.options?.hierarchyFull) {
         return Observable.empty<never>()
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,3 +182,4 @@ export {
  * Epics implementations
  */
 export {sendOperationEpicImpl} from './epics/view'
+export {removeMultivalueTagImpl} from './epics/data/removeMultivalueTag'

--- a/src/tests/testEpic.ts
+++ b/src/tests/testEpic.ts
@@ -55,6 +55,11 @@ export function testEpic(
         const nextActionNotifications = actual
             .filter(item => item.notification.kind === 'N')
             .map(item => item.notification.value)
+        actual
+        .filter(item => item.notification.kind === 'E' )
+        .forEach(item => {
+            console.error(item.notification.error)
+        })
         callback(nextActionNotifications)
     })
     testScheduler

--- a/src/utils/tree.ts
+++ b/src/utils/tree.ts
@@ -22,7 +22,7 @@
 import {DataNode, TreeNodeBidirectional, TreeNodeDescending} from '../interfaces/tree'
 
 /**
- * Modifies input array by assigning each element:
+ * Assigns for each element:
  *
  * - `parent` property, which is a reference to parent mode found through `parentId` match.
  * - `children` property, which is an array of references to child nodes.
@@ -30,10 +30,11 @@ import {DataNode, TreeNodeBidirectional, TreeNodeDescending} from '../interfaces
  * `parentId`: '0' considered a root pseudo-node
  *
  * @param flat Flat array representation of tree structure
+ * @returns New array
  */
 export function assignTreeLinks<T extends DataNode>(flat: T[]) {
+    const result = flat.map(item => ({ ...item })) as Array<T & TreeNodeBidirectional>
     const map: Record<string, number> = {}
-    const result = flat as Array<T & TreeNodeBidirectional>
     result.forEach(item => {
         if (!item.parentId || item.parentId === '0') {
             return


### PR DESCRIPTION
See #443 

`hierarchyTraverse` diselect bugfix. 

Additional filter for `wasLastInData` has been added to `currentLevelData` check, which excludes from `currentLevelData` array those that have been diselected.

MVG field tags will inherit behavior delete items from the hierarchy widget with which it is associated. Unavailable close option before AssocPopup is ready.

**_bugfix:_**
- Application crach when `AssocPopup` widget is not Hierarchy without `meta.options`
- Fix match popup pendingChanges for not Hierarchy `AssocPopup`