### PR TITLE
More clear epic for handling drilldown filters, do not put empty filters in the store (#374)

### DIFF
--- a/src/reducers/screen.ts
+++ b/src/reducers/screen.ts
@@ -389,8 +389,12 @@ export function screen(state = initialState, action: AnyAction): ScreenState {
         }
         case types.bcRemoveFilter: {
             const { bcName, filter } = action.payload
-            const prevFilters = state.filters[bcName] || []
-            const newFilters = prevFilters.filter(item => item.fieldName !== filter?.fieldName || item.type !== item.type)
+            const prevBcFilters = state.filters[bcName] || []
+            const newBcFilters = prevBcFilters.filter(item => item.fieldName !== filter?.fieldName || item.type !== item.type)
+            const newFilters = { ...state.filters, [bcName]: newBcFilters }
+            if (!newBcFilters.length) {
+                delete newFilters[bcName]
+            }
             return {
                 ...state,
                 bo: {
@@ -403,13 +407,12 @@ export function screen(state = initialState, action: AnyAction): ScreenState {
                         }
                     }
                 },
-                filters: {
-                    ...state.filters,
-                    [bcName]: newFilters
-                }
+                filters: newFilters
             }
         }
         case types.bcRemoveAllFilters: {
+            const filters = { ...state.filters }
+            delete filters[action.payload.bcName]
             return {
                 ...state,
                 bo: {
@@ -422,10 +425,7 @@ export function screen(state = initialState, action: AnyAction): ScreenState {
                         }
                     }
                 },
-                filters: {
-                    ...state.filters,
-                    [action.payload.bcName]: []
-                }
+                filters
             }
         }
         case types.bcAddSorter: {


### PR DESCRIPTION
Rewrite for handling inner drilldowns with filters:
1) Existing filters are cleared only when drilldown specifies its own filters or explicitly says that filters should be cleared via empty string filter expression. Otherwise filters are preserved, the same way as they are preserved when navigating between views via menu.
2) Drilldown to the same view with explicit clearing of filters now should correctly fire `bcForceUpdate` (adressess #374)
3) Empty filters now completely removed from the store instead of hanging with empty objects leading to various checks throughout the code thinking that filters are set for the BC