### PR TITLE
parseFilters should return null instead of empty array

### DIFF
--- a/src/utils/__tests__/filters.test.ts
+++ b/src/utils/__tests__/filters.test.ts
@@ -144,6 +144,12 @@ describe('parseFilters', () => {
         expect(spy).toHaveBeenCalled()
         spy.mockRestore()
     })
+
+    it('returns null on empty input', () => {
+        expect(parseFilters('')).toBe(null)
+        expect(parseFilters(null)).toBe(null)
+        expect(parseFilters(undefined)).toBe(null)
+    })
 })
 
 describe('parseSorters', () => {

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -81,7 +81,7 @@ export function parseFilters(defaultFilters: string) {
             })
         }
     })
-    return result
+    return result.length ? result : null
 }
 
 /**


### PR DESCRIPTION
Broken by [#430](https://github.com/tesler-platform/tesler-ui/pull/430/files#diff-b43c7ecdde65a63b9d877c9da877c710R84)