### PR TITLE
MVG field. Clickable empty area.

### DIFF
--- a/src/components/ui/Multivalue/MultivalueTag.less
+++ b/src/components/ui/Multivalue/MultivalueTag.less
@@ -4,6 +4,7 @@
     width: 100%;
     border: 1px solid #b3b3b3;
     padding: 4px 4px 4px 11px;
+    cursor: pointer;
 
     :global {
         .ant-tag {

--- a/src/components/ui/Multivalue/MultivalueTag.tsx
+++ b/src/components/ui/Multivalue/MultivalueTag.tsx
@@ -43,6 +43,7 @@ const MultivalueTag: React.FunctionComponent<MultivalueTagProps> = (props) => {
                 styles.multivalue,
                 { [styles.disabled]: props.disabled, [styles.error]: props.metaError })
             }
+            onClick={loading && props.disabled ? undefined : handleOpen}
         >
             <div
                 data-text={props.placeholder}
@@ -51,6 +52,7 @@ const MultivalueTag: React.FunctionComponent<MultivalueTagProps> = (props) => {
                     { [styles.disabled]: props.disabled })}>
                 { (props.value || []).map(val => {
                     return <Tag
+                        onClick={(e) => {e.stopPropagation()}}
                         title={val.value}
                         closable={!props.disabled}
                         id={val.id}


### PR DESCRIPTION
See #453 

Added an event to an empty area of ​​the `multivalue` field between `Tag`. The event repeats the event of clicking on the folder icon and is available after loading the popup metadata. Available only when the field is active. Child elements as `Tag` do not inherit behavior.