### PR TITLE
Remove Multivalue tag bugs

### DIFF
--- a/src/epics/__tests__/data/removeMultivalueTag.test.ts
+++ b/src/epics/__tests__/data/removeMultivalueTag.test.ts
@@ -244,6 +244,39 @@ describe('removeMultivalueTag for full hierarchies', () => {
             }))
         })
     })
+
+    it('removes associated item for non-hierarchies', () => {
+        store.getState().data.bcExamplePopup = getData()
+        store.getState().view.widgets[0].options = {
+            hierarchyFull: false,
+            hierarchy: undefined,
+            hierarchySameBc: false,
+        }
+        store.getState().view.pendingDataChanges.bcExamplePopup = {
+            '932': { _associate: true, name: 'one three two' }
+        }
+        const removedItem = { id: '921', value: 'one' }
+        const dataItem = getSelectedItems().filter(item => item.id !== removedItem.id)
+        const action = $do.removeMultivalueTag({
+            bcName: 'bcExample',
+            popupBcName: 'bcExamplePopup',
+            cursor: '1',
+            associateFieldKey: 'exampleField',
+            dataItem,
+            removedItem
+        })
+        const epic = removeMultivalueTag(ActionsObservable.of(action), store)
+        testEpic(epic, (result) => {
+            expect(result[0]).toEqual(expect.objectContaining({
+                type: coreActions.changeDataItem,
+                payload: {
+                    bcName: 'bcExamplePopup',
+                    cursor: '921',
+                    dataItem: { _associate: false, id: '921', value: 'one' },
+                }
+            }))
+        })
+    })
 })
 
 function getWidgetMeta(): WidgetTableMeta {

--- a/src/middlewares/requiredFieldsMiddleware.ts
+++ b/src/middlewares/requiredFieldsMiddleware.ts
@@ -119,7 +119,7 @@ function getRequiredFieldsMissing(record: DataItem, pendingChanges: PendingDataI
             falsyValue = true
         }
         if (field.required && falsyValue) {
-            result[field.key] = null
+            result[field.key] = Array.isArray(effectiveValue) ? [] : null
         }
     })
     return Object.keys(result).length > 0 ? result : null

--- a/src/reducers/view.ts
+++ b/src/reducers/view.ts
@@ -206,6 +206,7 @@ export function view(state = initialState, action: AnyAction, store: Store): Vie
                 const isEmpty = nextPending[fieldKey] === null
                     || nextPending[fieldKey] === undefined
                     || nextPending[fieldKey] === ''
+                    || (Array.isArray(nextPending[fieldKey]) && Object.keys(nextPending[fieldKey]).length === 0)
                 if (required && isEmpty) {
                     nextValidationFails[fieldKey] = i18n.t('This field is mandatory') as string
                 }


### PR DESCRIPTION
See #478

Process of checking hierarchy options and actions on them has been changed.
Hierarchy options have different logic for changing elements in callee BC and popup BC, depending of type hierarchy. These options have their own branches.
There was no branch for changing dataItem if popup widget is not hierarchy. In this case, you need to change dataItem for callee BC and popup BC. This is the default branch of `removeMultivalueTag` Epic.

Validation errors reset pending data to `null`. This values ​​are not involved in the math popup tags.
Now validation error used `[]` for array like empty objects. With empty pendingData as `[]` action `showViewPopup` works correctly.
