### PR TITLE
Extension filter object interface `bcFilter`. SearchHighlight enhancement.

### DIFF
--- a/src/components/ColumnTitle/ColumnFilter.tsx
+++ b/src/components/ColumnTitle/ColumnFilter.tsx
@@ -61,6 +61,7 @@ export const ColumnFilter: React.FC<ColumnFilterProps> = (props) => {
             dispatch($do.showViewPopup({
                 bcName: fieldMeta.popupBcName,
                 calleeBCName: props.widget?.bcName,
+                calleeWidgetName: props.widget?.name,
                 assocValueKey: fieldMeta.assocValueKey,
                 associateFieldKey: fieldMeta.associateFieldKey,
                 isFilter: true

--- a/src/components/Field/Field.test.tsx
+++ b/src/components/Field/Field.test.tsx
@@ -4,12 +4,15 @@ import {Store} from 'redux'
 import {Provider} from 'react-redux'
 import {mockStore} from '../../tests/mockStore'
 import {
+    CheckboxFieldMeta,
     DateFieldMeta,
     DictionaryFieldMeta,
+    InputFieldMeta,
     MultiFieldMeta,
     MultivalueFieldMeta,
     NumberFieldMeta,
     PickListFieldMeta,
+    RadioButtonFieldMeta,
     TextFieldMeta,
     WidgetField,
     WidgetTypes
@@ -19,6 +22,9 @@ import {FieldType} from '../../interfaces/view'
 import Field from './Field'
 import ActionLink from '../ui/ActionLink/ActionLink'
 import ReadOnlyField from '../ui/ReadOnlyField/ReadOnlyField'
+import CheckboxPicker from '../ui/CheckboxPicker/CheckboxPicker'
+import RadioButton from '../ui/RadioButton/RadioButton'
+import MultivalueHover from '../ui/Multivalue/MultivalueHover'
 
 const testBcName = 'bcExample'
 const initialCursor = '1001'
@@ -139,7 +145,7 @@ describe('Readonly field drilldown', () => {
         expect(wrapper.find('Memo(DatePickerField)').length).toEqual(1)
     })
 
-    it('should render NumberInput', () => {
+    it('should render NumberInput at Number type', () => {
         const numberFieldMeta = {key: 'someInput', type: FieldType.number, label: fieldName,}
         const numberFieldProperties = {...fieldProperties, readonly: false}
         const wrapper = mount(
@@ -151,6 +157,86 @@ describe('Readonly field drilldown', () => {
             </Provider>
         )
         expect(wrapper.find('Memo(NumberInput)').length).toEqual(1)
+    })
+
+    it('should render NumberInput at Money type', () => {
+        const numberFieldMeta = {key: 'someInput', type: FieldType.money, label: fieldName,}
+        const numberFieldProperties = {...fieldProperties, readonly: false}
+        const wrapper = mount(
+            <Provider store={store}>
+                <Field
+                    {...numberFieldProperties}
+                    widgetFieldMeta={numberFieldMeta as NumberFieldMeta}
+                />
+            </Provider>
+        )
+        expect(wrapper.find('Memo(NumberInput)').length).toEqual(1)
+    })
+
+    it('should render NumberInput at Percent type', () => {
+        const numberFieldMeta = {key: 'someInput', type: FieldType.percent, label: fieldName,}
+        const numberFieldProperties = {...fieldProperties, readonly: false}
+        const wrapper = mount(
+            <Provider store={store}>
+                <Field
+                    {...numberFieldProperties}
+                    widgetFieldMeta={numberFieldMeta as NumberFieldMeta}
+                />
+            </Provider>
+        )
+        expect(wrapper.find('Memo(NumberInput)').length).toEqual(1)
+    })
+
+    it('should render Checkbox', () => {
+        const checkboxFieldMeta = {key: 'someInput', type: FieldType.checkbox, label: fieldName,}
+        const wrapper = mount(
+            <Provider store={store}>
+                <Field
+                    {...fieldProperties}
+                    widgetFieldMeta={checkboxFieldMeta as CheckboxFieldMeta}
+                />
+            </Provider>
+        )
+        expect(wrapper.find(CheckboxPicker).length).toEqual(1)
+    })
+
+    it('should render Radio', () => {
+        const radioButtonFieldMeta = {key: 'someInput', type: FieldType.radio, label: fieldName,}
+        const wrapper = mount(
+            <Provider store={store}>
+                <Field
+                    {...fieldProperties}
+                    widgetFieldMeta={radioButtonFieldMeta as RadioButtonFieldMeta}
+                />
+            </Provider>
+        )
+        expect(wrapper.find(RadioButton).length).toEqual(1)
+    })
+
+    it('should render Hint', () => {
+        const hintFieldMeta = {key: 'someInput', type: FieldType.hint, label: fieldName,}
+        const wrapper = mount(
+            <Provider store={store}>
+                <Field
+                    {...fieldProperties}
+                    widgetFieldMeta={hintFieldMeta as InputFieldMeta}
+                />
+            </Provider>
+        )
+        expect(wrapper.find(ReadOnlyField).length).toEqual(1)
+    })
+
+    it('should render MultivalueHover', () => {
+        const multivalueHoverFieldMeta = {key: 'someInput', type: FieldType.multivalueHover, label: fieldName,}
+        const wrapper = mount(
+            <Provider store={store}>
+                <Field
+                    {...fieldProperties}
+                    widgetFieldMeta={multivalueHoverFieldMeta as MultivalueFieldMeta}
+                />
+            </Provider>
+        )
+        expect(wrapper.find(MultivalueHover).length).toEqual(1)
     })
 
     it('should render Dictionary', () => {

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -144,7 +144,8 @@ export const Field: FunctionComponent<FieldProps> = (props) => {
         placeholder,
         readOnly: props.readonly,
         backgroundColor: bgColor,
-        onDrillDown: handleDrilldown
+        onDrillDown: handleDrilldown,
+        filterValue: props.filterValue
     }
     const commonInputProps: any = {
         cursor: props.cursor,
@@ -187,6 +188,7 @@ export const Field: FunctionComponent<FieldProps> = (props) => {
                 value={(value || '').toString()}
                 showTime={props.widgetFieldMeta.type === FieldType.dateTime}
                 showSeconds={props.widgetFieldMeta.type === FieldType.dateTimeWithSeconds}
+                filterValue={props.filterValue}
             />
             break
         case FieldType.number:
@@ -230,6 +232,7 @@ export const Field: FunctionComponent<FieldProps> = (props) => {
                 fieldName={props.widgetFieldMeta.key}
                 onChange={handleChange}
                 multiple={props.widgetFieldMeta.multiple}
+                filterValue={props.filterValue}
             />
             break
         case FieldType.text:
@@ -239,6 +242,7 @@ export const Field: FunctionComponent<FieldProps> = (props) => {
                 defaultValue={value as any}
                 onChange={handleChange}
                 className={cn({[readOnlyFieldStyles.error]: props.metaError})}
+                filterValue={props.filterValue}
             />
             break
         case FieldType.multifield:
@@ -420,9 +424,11 @@ function mapStateToProps(store: Store, ownProps: FieldOwnProps) {
     const pendingValue = store.view.pendingDataChanges[ownProps.bcName]
     ?.[ownProps.cursor]
     ?.[ownProps.widgetFieldMeta.key]
+    const viewName = store.view.name
     const widget = store.view.widgets.find(item => item.name === ownProps.widgetName)
     const showErrorPopup = widget?.type !== WidgetTypes.Form && !ownProps.disableHoverError
     const filterValue = store.screen.filters[ownProps.bcName]
+        ?.filter(filterItem => filterItem.widgetName === widget.name && filterItem.viewName === viewName)
         ?.find(filter => filter.fieldName === ownProps.widgetFieldMeta.key)
         ?.value.toString()
     return {

--- a/src/components/FileUpload/FileUpload.tsx
+++ b/src/components/FileUpload/FileUpload.tsx
@@ -22,7 +22,7 @@ export interface FileUploadOwnProps {
     fileSource: string,
     readOnly?: boolean,
     disabled?: boolean,
-    metaError: string,
+    metaError?: string,
     snapshotKey?: string,
     snapshotFileIdKey?: string
 }

--- a/src/components/FilterPopup/FilterPopup.tsx
+++ b/src/components/FilterPopup/FilterPopup.tsx
@@ -45,6 +45,9 @@ export const FilterPopup: React.FC<FilterPopupProps> = (props) => {
     const widget = useSelector((store: Store) => {
         return store.view.widgets.find(item => item.name === props.widgetName)
     })
+    const viewName = useSelector((store: Store) => {
+        return store.view.name
+    })
     const filter = useSelector((store: Store) => {
         return store.screen.filters[widget?.bcName]?.find(item => item.fieldName === props.fieldKey)
     })
@@ -59,7 +62,9 @@ export const FilterPopup: React.FC<FilterPopupProps> = (props) => {
         const newFilter: BcFilter = {
             type: getFilterType(widgetMeta.type),
             value: props.value,
-            fieldName: props.fieldKey
+            fieldName: props.fieldKey,
+            viewName,
+            widgetName: widget.name
         }
         if (!props.value) {
             dispatch($do.bcRemoveFilter({ bcName: widget.bcName, filter }))

--- a/src/components/InlinePickList/InlinePickList.tsx
+++ b/src/components/InlinePickList/InlinePickList.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {DataItem, PickMap} from '../../interfaces/data'
 import ReadOnlyField from '../ui/ReadOnlyField/ReadOnlyField'
-import {ChangeDataItemPayload} from '../Field/Field'
+import {ChangeDataItemPayload, BaseFieldProps} from '../Field/Field'
 import Select from '../ui/Select/Select'
 import {$do} from '../../index'
 import {connect} from 'react-redux'
@@ -13,19 +13,13 @@ import {useDebounce} from '../../hooks/useDebounce'
 import cn from 'classnames'
 import {useTranslation} from 'react-i18next'
 
-interface InlinePickListOwnProps {
+interface InlinePickListOwnProps extends BaseFieldProps {
     fieldName: string,
     searchSpec: string,
     bcName: string,
     popupBcName: string,
-    cursor: string,
     pickMap: PickMap,
-    disabled?: boolean,
-    readonly?: boolean,
     value?: string,
-    className?: string,
-    onDrillDown?: () => void,
-    backgroundColor?: string,
     placeholder?:  string
 }
 
@@ -39,8 +33,10 @@ interface InlinePickListProps extends InlinePickListOwnProps {
 const InlinePickList: React.FunctionComponent<InlinePickListProps> = (props) => {
     const {t} = useTranslation()
 
-    if (props.readonly) {
+    if (props.readOnly) {
         return <ReadOnlyField
+            widgetName={props.widgetName}
+            meta={props.meta}
             className={props.className}
             backgroundColor={props.backgroundColor}
             onDrillDown={props.onDrillDown}

--- a/src/components/Multivalue/MultivalueField.tsx
+++ b/src/components/Multivalue/MultivalueField.tsx
@@ -13,8 +13,8 @@ export interface MultivalueFieldOwnProps {
     defaultValue: MultivalueSingleValue[],
     widgetFieldMeta: MultivalueFieldMeta,
     bcName: string,
-    disabled: boolean,
-    metaError: string,
+    disabled?: boolean,
+    metaError?: string,
     placeholder?: string
 }
 

--- a/src/components/PickListField/PickListField.tsx
+++ b/src/components/PickListField/PickListField.tsx
@@ -4,26 +4,20 @@ import {$do} from '../../actions/actions'
 import {connect} from 'react-redux'
 import {PickMap} from '../../interfaces/data'
 import ReadOnlyField from '../ui/ReadOnlyField/ReadOnlyField'
-import {ChangeDataItemPayload} from '../Field/Field'
+import {ChangeDataItemPayload, BaseFieldProps} from '../Field/Field'
 import {Store} from '../../interfaces/store'
 import {buildBcUrl} from '../../utils/strings'
 
-interface IPickListWidgetInputOwnProps {
+interface IPickListWidgetInputOwnProps extends BaseFieldProps {
     parentBCName: string,
     bcName: string,
-    cursor: string,
     pickMap: PickMap,
     value?: string,
-    disabled?: boolean,
-    readOnly?: boolean,
-    onChange: (payload: ChangeDataItemPayload) => void,
-    className?: string,
-    onDrillDown?: () => void,
-    backgroundColor?: string,
     placeholder?: string
 }
 
 interface IPickListWidgetInputProps extends IPickListWidgetInputOwnProps {
+    onChange: (payload: ChangeDataItemPayload) => void,
     onClick: (bcName: string, pickMap: PickMap) => void,
     popupRowMetaDone: boolean
 }
@@ -31,6 +25,8 @@ interface IPickListWidgetInputProps extends IPickListWidgetInputOwnProps {
 const PickListField: React.FunctionComponent<IPickListWidgetInputProps> = (props) => {
     if (props.readOnly) {
         return <ReadOnlyField
+            widgetName={props.widgetName}
+            meta={props.meta}
             className={props.className}
             backgroundColor={props.backgroundColor}
             onDrillDown={props.onDrillDown}
@@ -69,7 +65,7 @@ const PickListField: React.FunctionComponent<IPickListWidgetInputProps> = (props
     />
 }
 
-function mapStateToProps(store: Store,ownProps: IPickListWidgetInputOwnProps) {
+function mapStateToProps(store: Store, ownProps: IPickListWidgetInputOwnProps) {
     const popupBcName = ownProps?.bcName
     const bcUrl = buildBcUrl(popupBcName, true)
     const popupRowMetaDone = !!store.view.rowMeta[popupBcName]?.[bcUrl]?.fields

--- a/src/components/ui/DatePickerField/DatePickerField.tsx
+++ b/src/components/ui/DatePickerField/DatePickerField.tsx
@@ -5,12 +5,9 @@ import {DatePickerProps} from 'antd/es/date-picker/interface'
 import * as styles from './DatePickerField.less'
 import cn from 'classnames'
 import ReadOnlyField from '../ReadOnlyField/ReadOnlyField'
-import SearchHighlight from '../SearchHightlight/SearchHightlight'
-import {escapedSrc} from '../../../utils/strings'
+import {BaseFieldProps} from '../../Field/Field'
 
-export interface IDatePickerFieldProps {
-    readOnly?: boolean,
-    disabled?: boolean,
+export interface IDatePickerFieldProps extends BaseFieldProps {
     value?: string | null,
     onChange?: (date: string | null) => void,
     showToday?: boolean,
@@ -20,12 +17,9 @@ export interface IDatePickerFieldProps {
     showTime?: boolean,
     monthYear?: boolean,
     showSeconds?: boolean,
-    backgroundColor?: string | null,
-    className?: string,
     resetForceFocus?: () => void,
     dateFormatter?: (date: moment.Moment) => string,
     calendarContainer?: HTMLElement,
-    onDrillDown?: () => void,
     filterValue?: string
 }
 
@@ -48,16 +42,13 @@ const DatePickerField: React.FunctionComponent<IDatePickerFieldProps> = (props) 
     if (props.readOnly) {
         const datePickerFormat = DatePickerFieldFormat(value, showTime, showSeconds, monthYear)
         return <ReadOnlyField
+            widgetName={props.widgetName}
+            meta={props.meta}
             className={props.className}
             backgroundColor={props.backgroundColor}
             onDrillDown={props.onDrillDown}
         >
-            {props.filterValue
-                ? <SearchHighlight
-                    source={(datePickerFormat || '').toString()}
-                    search={escapedSrc(datePickerFormat || '')}
-                    match={formatString => <b>{formatString}</b>}/>
-                : datePickerFormat}
+            {datePickerFormat}
         </ReadOnlyField>
     }
 

--- a/src/components/ui/DatePickerField/DatePickerField.tsx
+++ b/src/components/ui/DatePickerField/DatePickerField.tsx
@@ -5,6 +5,8 @@ import {DatePickerProps} from 'antd/es/date-picker/interface'
 import * as styles from './DatePickerField.less'
 import cn from 'classnames'
 import ReadOnlyField from '../ReadOnlyField/ReadOnlyField'
+import SearchHighlight from '../SearchHightlight/SearchHightlight'
+import {escapedSrc} from '../../../utils/strings'
 
 export interface IDatePickerFieldProps {
     readOnly?: boolean,
@@ -23,7 +25,8 @@ export interface IDatePickerFieldProps {
     resetForceFocus?: () => void,
     dateFormatter?: (date: moment.Moment) => string,
     calendarContainer?: HTMLElement,
-    onDrillDown?: () => void
+    onDrillDown?: () => void,
+    filterValue?: string
 }
 
 const dateFormat = moment.ISO_8601
@@ -43,12 +46,18 @@ const DatePickerField: React.FunctionComponent<IDatePickerFieldProps> = (props) 
     } = props
 
     if (props.readOnly) {
+        const datePickerFormat = DatePickerFieldFormat(value, showTime, showSeconds, monthYear)
         return <ReadOnlyField
             className={props.className}
             backgroundColor={props.backgroundColor}
             onDrillDown={props.onDrillDown}
         >
-            {DatePickerFieldFormat(value, showTime, showSeconds, monthYear)}
+            {props.filterValue
+                ? <SearchHighlight
+                    source={(datePickerFormat || '').toString()}
+                    search={escapedSrc(datePickerFormat || '')}
+                    match={formatString => <b>{formatString}</b>}/>
+                : datePickerFormat}
         </ReadOnlyField>
     }
 

--- a/src/components/ui/Dictionary/Dictionary.test.tsx
+++ b/src/components/ui/Dictionary/Dictionary.test.tsx
@@ -1,7 +1,9 @@
 import {mount, shallow} from 'enzyme'
 import Dictionary, {DictionaryProps, getIconByParams} from './Dictionary'
 import * as React from 'react'
-import {MultivalueSingleValue} from 'interfaces/data'
+import {MultivalueSingleValue} from '../../../interfaces/data'
+import {FieldType} from '../../../interfaces/view'
+import {BaseFieldProps} from '../../Field/Field'
 
 const defValues = [
     {value: 'German'},
@@ -25,6 +27,7 @@ const defFieldName = 'languageList'
 
 describe('Dictionary test in default mode', () => {
     const props: DictionaryProps = {
+        ...baseFieldProps,
         value: 'Spanish',
         fieldName: defFieldName,
         values:  defValues
@@ -128,6 +131,7 @@ describe('Dictionary test in default mode', () => {
 
 describe('Dictionary test in multiple mode', () => {
     const props: DictionaryProps = {
+        ...baseFieldProps,
         value: [{value: 'Spanish', id: 'Spanish'}, {value: 'German', id: 'German'}],
         multiple: true,
         fieldName: defFieldName,
@@ -215,3 +219,12 @@ describe('getIconByParams test', () => {
         expect(wrapper.find('Icon').findWhere(i => i.props().style.color === 'red').length).toEqual(1)
     })
 })
+
+const baseFieldProps: BaseFieldProps = {
+    widgetName: 'widget-example',
+    cursor: null,
+    meta: {
+        type: FieldType.dictionary,
+        key: 'field-example'
+    }
+}

--- a/src/components/ui/Dictionary/Dictionary.tsx
+++ b/src/components/ui/Dictionary/Dictionary.tsx
@@ -3,26 +3,19 @@ import {Icon, Select as AntdSelect} from 'antd'
 import Select, {SelectProps} from '../Select/Select'
 import ReadOnlyField from '../ReadOnlyField/ReadOnlyField'
 import {MultivalueSingleValue} from '../../../interfaces/data'
-import SearchHighlight from '../SearchHightlight/SearchHightlight'
-import {escapedSrc} from '../../../utils/strings'
+import {BaseFieldProps} from '../../Field/Field'
 
-export interface DictionaryProps {
+export interface DictionaryProps extends BaseFieldProps {
     value?: MultivalueSingleValue[] | string | null,
     onChange?: (value: MultivalueSingleValue[] | string) => void,
     values: Array<{value: string, icon?: string}>,
-    readOnly?: boolean,
-    disabled?: boolean,
     fieldName: string,
     placeholder?: string,
     style?: React.CSSProperties,
     metaIcon?: JSX.Element,
     valueIcon?: string,
     popupContainer?: HTMLElement,
-    className?: string,
-    backgroundColor?: string,
-    onDrillDown?: () => void,
-    multiple?: boolean,
-    filterValue?: string
+    multiple?: boolean
 }
 
 const Dictionary: React.FunctionComponent<DictionaryProps> = (props) => {
@@ -32,16 +25,13 @@ const Dictionary: React.FunctionComponent<DictionaryProps> = (props) => {
             readOnlyValue = (readOnlyValue as MultivalueSingleValue[]).map(i => i.value).join((', '))
         }
         return <ReadOnlyField
+            widgetName={props.widgetName}
+            meta={props.meta}
             className={props.className}
             backgroundColor={props.backgroundColor}
             onDrillDown={props.onDrillDown}
         >
-            {props.filterValue
-                ? <SearchHighlight
-                    source={(readOnlyValue || '').toString()}
-                    search={escapedSrc(props.filterValue)}
-                    match={formatString => <b>{formatString}</b>}/>
-                : readOnlyValue}
+            {readOnlyValue}
         </ReadOnlyField>
     }
 

--- a/src/components/ui/Dictionary/Dictionary.tsx
+++ b/src/components/ui/Dictionary/Dictionary.tsx
@@ -3,6 +3,8 @@ import {Icon, Select as AntdSelect} from 'antd'
 import Select, {SelectProps} from '../Select/Select'
 import ReadOnlyField from '../ReadOnlyField/ReadOnlyField'
 import {MultivalueSingleValue} from '../../../interfaces/data'
+import SearchHighlight from '../SearchHightlight/SearchHightlight'
+import {escapedSrc} from '../../../utils/strings'
 
 export interface DictionaryProps {
     value?: MultivalueSingleValue[] | string | null,
@@ -19,7 +21,8 @@ export interface DictionaryProps {
     className?: string,
     backgroundColor?: string,
     onDrillDown?: () => void,
-    multiple?: boolean
+    multiple?: boolean,
+    filterValue?: string
 }
 
 const Dictionary: React.FunctionComponent<DictionaryProps> = (props) => {
@@ -33,7 +36,12 @@ const Dictionary: React.FunctionComponent<DictionaryProps> = (props) => {
             backgroundColor={props.backgroundColor}
             onDrillDown={props.onDrillDown}
         >
-            {readOnlyValue}
+            {props.filterValue
+                ? <SearchHighlight
+                    source={(readOnlyValue || '').toString()}
+                    search={escapedSrc(props.filterValue)}
+                    match={formatString => <b>{formatString}</b>}/>
+                : readOnlyValue}
         </ReadOnlyField>
     }
 

--- a/src/components/ui/Multivalue/MultivalueHover.tsx
+++ b/src/components/ui/Multivalue/MultivalueHover.tsx
@@ -3,18 +3,26 @@ import {Icon, Popover} from 'antd'
 import {DataValue, MultivalueSingleValue} from '../../../interfaces/data'
 import styles from './MultivalueHover.less'
 import cn from 'classnames'
+import SearchHighlight from '../SearchHightlight/SearchHightlight'
+import {escapedSrc} from '../../../utils/strings'
 
 export interface MultivalueHoverProps {
     data: MultivalueSingleValue[],
     displayedValue: DataValue,
     onDrillDown?: () => void,
-    className?: string
+    className?: string,
+    filterValue?: string
 }
 
 const Multivalue: React.FunctionComponent<MultivalueHoverProps> = (props) => {
     const displayedItem = (props.displayedValue !== undefined && props.displayedValue !== null)
         ? <p className={cn(styles.displayedValue, props.className)} onClick={props.onDrillDown}>
-            {props.displayedValue}
+            {props.filterValue
+                ? <SearchHighlight
+                    source={(props.displayedValue || '').toString()}
+                    search={escapedSrc(props.filterValue)}
+                    match={formatString => <b>{formatString}</b>}/>
+                : props.displayedValue}
         </p>
         : <Icon className={cn(props.className)} type="left-circle" onClick={props.onDrillDown}/>
     const fields = props.data.map((multivalueSingleValue, index) => {

--- a/src/components/ui/Multivalue/MultivalueHover.tsx
+++ b/src/components/ui/Multivalue/MultivalueHover.tsx
@@ -5,22 +5,27 @@ import styles from './MultivalueHover.less'
 import cn from 'classnames'
 import SearchHighlight from '../SearchHightlight/SearchHightlight'
 import {escapedSrc} from '../../../utils/strings'
+import {useWidgetHighlightFilter} from '../../../hooks/useWidgetFilter'
+import {BaseFieldProps} from '../../Field/Field'
 
-export interface MultivalueHoverProps {
+export interface MultivalueHoverProps extends BaseFieldProps {
     data: MultivalueSingleValue[],
     displayedValue: DataValue,
     onDrillDown?: () => void,
-    className?: string,
-    filterValue?: string
+    className?: string
 }
 
 const Multivalue: React.FunctionComponent<MultivalueHoverProps> = (props) => {
+    const filterKey = useWidgetHighlightFilter(props.widgetName, props.meta?.key)?.value?.toString()
+    const filterValue = props.data
+        ?.find(bcDataItem => filterKey?.split(',')?.includes(bcDataItem.id))
+        ?.value.toString()
     const displayedItem = (props.displayedValue !== undefined && props.displayedValue !== null)
         ? <p className={cn(styles.displayedValue, props.className)} onClick={props.onDrillDown}>
-            {props.filterValue
+            {filterValue
                 ? <SearchHighlight
                     source={(props.displayedValue || '').toString()}
-                    search={escapedSrc(props.filterValue)}
+                    search={escapedSrc(filterValue)}
                     match={formatString => <b>{formatString}</b>}/>
                 : props.displayedValue}
         </p>

--- a/src/components/ui/NumberInput/NumberInput.tsx
+++ b/src/components/ui/NumberInput/NumberInput.tsx
@@ -5,25 +5,23 @@ import {
 import {NumberTypes, fractionsRound, NumberInputFormat} from '../../../components/ui/NumberInput/formaters'
 import ReadOnlyField from '../ReadOnlyField/ReadOnlyField'
 import {InputProps} from 'antd/es/input'
+import {BaseFieldProps} from '../../Field/Field'
 
-export interface NumberInputProps {
-    readOnly?: boolean,
-    disabled?: boolean,
-    backgroundColor?: string,
+export interface NumberInputProps extends BaseFieldProps {
     onChange?: (value: number) => void,
     value: number,
     nullable?: boolean,
     digits?: number,
     type: NumberTypes,
     maxInput?: number,
-    className?: string,
-    onDrillDown?: () => void,
     forceFocus?: boolean
 }
 
 const NumberInput: React.FunctionComponent<NumberInputProps> = (props) => {
     if (props.readOnly) {
         return <ReadOnlyField
+            widgetName={props.widgetName}
+            meta={props.meta}
             className={props.className}
             backgroundColor={props.backgroundColor}
             onDrillDown={props.onDrillDown}

--- a/src/components/ui/RadioButton/RadioButton.test.tsx
+++ b/src/components/ui/RadioButton/RadioButton.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import {mount} from 'enzyme'
 import RadioButton from './RadioButton'
+import {FieldType} from '../../../interfaces/view'
+import {BaseFieldProps} from '../../Field/Field'
 
 describe('RadioButton component test', () => {
     const values = [
@@ -12,6 +14,7 @@ describe('RadioButton component test', () => {
     it('component should render 3 values', () => {
         const wrapper = mount(
             <RadioButton
+                {...baseFieldProps}
                 value={'testRadio-2'}
                 values={values}
             />
@@ -30,6 +33,7 @@ describe('RadioButton component test', () => {
         })
         const wrapper = mount(
             <RadioButton
+                {...baseFieldProps}
                 values={values}
                 onChange={onChange}
             />
@@ -46,6 +50,7 @@ describe('RadioButton component test', () => {
     it('values is null or undefined', () => {
         const wrapper = mount(
             <RadioButton
+                {...baseFieldProps}
                 values={null}
             />
         )
@@ -53,3 +58,12 @@ describe('RadioButton component test', () => {
         expect(wrapper.find('input[type="radio"]').length).toBe(0)
     })
 })
+
+const baseFieldProps: BaseFieldProps = {
+    widgetName: 'widget-example',
+    cursor: null,
+    meta: {
+        type: FieldType.radio,
+        key: 'field-example'
+    }
+}

--- a/src/components/ui/RadioButton/RadioButton.tsx
+++ b/src/components/ui/RadioButton/RadioButton.tsx
@@ -3,17 +3,13 @@ import {Radio} from 'antd'
 import ReadOnlyField from '../ReadOnlyField/ReadOnlyField'
 import {RadioChangeEvent} from 'antd/es/radio'
 import {getIconByParams} from '../Dictionary/Dictionary'
+import {BaseFieldProps} from '../../../components/Field/Field'
 
-export interface RadioButtonProps {
+export interface RadioButtonProps extends BaseFieldProps {
     value?: string | null,
     onChange?: (value: string) => void,
     values: Array<{ value: string, icon?: string }>,
-    readOnly?: boolean,
-    disabled?: boolean,
-    style?: React.CSSProperties,
-    className?: string,
-    backgroundColor?: string,
-    onDrillDown?: () => void
+    style?: React.CSSProperties
 }
 
 const RadioButton: React.FunctionComponent<RadioButtonProps> = (props) => {
@@ -21,6 +17,8 @@ const RadioButton: React.FunctionComponent<RadioButtonProps> = (props) => {
         const readOnlyValue = props.value ?? ''
 
         return <ReadOnlyField
+            widgetName={props.widgetName}
+            meta={props.meta}
             className={props.className}
             backgroundColor={props.backgroundColor}
             onDrillDown={props.onDrillDown}

--- a/src/components/ui/ReadOnlyField/ReadOnlyField.tsx
+++ b/src/components/ui/ReadOnlyField/ReadOnlyField.tsx
@@ -2,8 +2,20 @@ import React from 'react'
 import styles from './ReadOnlyField.less'
 import cn from 'classnames'
 import ActionLink from '../ActionLink/ActionLink'
+import {WidgetFieldBase} from '../../../interfaces/widget'
+import {useWidgetHighlightFilter} from '../../../hooks/useWidgetFilter'
+import SearchHighlight from '../SearchHightlight/SearchHightlight'
+import {escapedSrc} from '../../../utils/strings'
 
 export interface ReadOnlyFieldProps {
+    /**
+     * TODO: Will be mandatory in 2.0.0
+     */
+    widgetName?: string,
+    /**
+     * TODO: Will be mandatory in 2.0.0
+     */
+    meta?: WidgetFieldBase,
     backgroundColor?: string,
     className?: string,
     onDrillDown?: () => void,
@@ -11,19 +23,27 @@ export interface ReadOnlyFieldProps {
 }
 
 const ReadOnlyField: React.FunctionComponent<ReadOnlyFieldProps> = (props) => {
+    const filter = useWidgetHighlightFilter(props.widgetName, props.meta.key)
+    const displayedValue = filter
+        ? <SearchHighlight
+            source={(props.children || '').toString()}
+            search={escapedSrc(filter.value.toString())}
+            match={formatString => <b>{formatString}</b>}
+        />
+        : props.children
     return <span
         className={cn(
             styles.readOnlyField,
             {[styles.coloredField]: props.backgroundColor},
             props.className
         )}
-        style={props.backgroundColor ? {backgroundColor: props.backgroundColor} : null}
+        style={props.backgroundColor ? { backgroundColor: props.backgroundColor } : null}
     >
-        {(props.onDrillDown)
+        {props.onDrillDown
             ? <ActionLink onClick={props.onDrillDown}>
-                {props.children}
+                {displayedValue}
             </ActionLink>
-            : props.children
+            : displayedValue
         }
     </span>
 }

--- a/src/components/ui/TextArea/TextArea.test.tsx
+++ b/src/components/ui/TextArea/TextArea.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import {TextArea} from './TextArea'
 import {shallow} from 'enzyme'
+import SearchHighlight from '../SearchHightlight/SearchHightlight'
+import {escapedSrc} from '../../../utils/strings'
 
 describe('TextArea test', () => {
 
@@ -17,5 +19,11 @@ describe('TextArea test', () => {
     it('should render antd Popover', () => {
         const wrapper = shallow(<TextArea defaultValue={'testPopover'} popover/>)
         expect(wrapper.find('Popover').length).toEqual(1)
+    })
+
+    it('should render ReadOnlyField with SearchHighlight', () => {
+        const wrapper = shallow(<TextArea defaultValue={'test'} readOnly filterValue={'te'}/>)
+        expect(wrapper.find(SearchHighlight).props().source).toEqual('test')
+        expect(wrapper.find(SearchHighlight).props().search).toEqual(escapedSrc('te'))
     })
 })

--- a/src/components/ui/TextArea/TextArea.test.tsx
+++ b/src/components/ui/TextArea/TextArea.test.tsx
@@ -1,29 +1,49 @@
 import React from 'react'
 import {TextArea} from './TextArea'
 import {shallow} from 'enzyme'
-import SearchHighlight from '../SearchHightlight/SearchHightlight'
-import {escapedSrc} from '../../../utils/strings'
+import {BaseFieldProps} from '../../Field/Field'
+import {FieldType} from '../../../interfaces/view'
 
 describe('TextArea test', () => {
 
     it('should render ReadOnlyField', () => {
-        const wrapper = shallow(<TextArea defaultValue={'test'} readOnly/>)
+        const wrapper = shallow(
+            <TextArea
+                {...baseFieldProps}
+                defaultValue="test"
+                readOnly
+            />
+        )
         expect(wrapper.find('Memo(ReadOnlyField)').findWhere(i => i.text() === 'test').length).toBeGreaterThan(0)
     })
 
     it('should render antd TextArea', () => {
-        const wrapper = shallow(<TextArea defaultValue={'test'}/>)
+        const wrapper = shallow(
+            <TextArea
+                {...baseFieldProps}
+                defaultValue="test"
+            />
+        )
         expect(wrapper.find('TextArea').findWhere(i => i.prop('defaultValue') === 'test').length).toEqual(1)
     })
 
     it('should render antd Popover', () => {
-        const wrapper = shallow(<TextArea defaultValue={'testPopover'} popover/>)
+        const wrapper = shallow(
+            <TextArea
+                {...baseFieldProps}
+                defaultValue="test"
+                popover
+            />
+        )
         expect(wrapper.find('Popover').length).toEqual(1)
     })
-
-    it('should render ReadOnlyField with SearchHighlight', () => {
-        const wrapper = shallow(<TextArea defaultValue={'test'} readOnly filterValue={'te'}/>)
-        expect(wrapper.find(SearchHighlight).props().source).toEqual('test')
-        expect(wrapper.find(SearchHighlight).props().search).toEqual(escapedSrc('te'))
-    })
 })
+
+const baseFieldProps: BaseFieldProps = {
+    widgetName: 'widget-example',
+    cursor: null,
+    meta: {
+        type: FieldType.text,
+        key: 'field-example'
+    }
+}

--- a/src/components/ui/TextArea/TextArea.tsx
+++ b/src/components/ui/TextArea/TextArea.tsx
@@ -8,39 +8,30 @@ import InputDefaultClass from 'antd/lib/input/TextArea'
 import styles from './TextArea.less'
 import ReadOnlyField from '../ReadOnlyField/ReadOnlyField'
 import {TextAreaProps as AntdTextAreaProps} from 'antd/lib/input/TextArea'
-import SearchHighlight from '../SearchHightlight/SearchHightlight'
-import {escapedSrc} from '../../../utils/strings'
+import {BaseFieldProps} from '../../Field/Field'
 
 type AdditionalAntdTextAreaProps = Partial<Omit<AntdTextAreaProps, 'onChange'>>
-export interface TextAreaProps extends AdditionalAntdTextAreaProps {
+
+export interface TextAreaProps extends BaseFieldProps, AdditionalAntdTextAreaProps {
     defaultValue?: string | null,
     maxInput?: number,
     onChange?: (value: string) => void,
     popover?: boolean,
-    disabled?: boolean,
-    readOnly?: boolean,
     style?: React.CSSProperties,
     minRows?: number,
-    maxRows?: number,
-    className?: string,
-    backgroundColor?: string,
-    onDrillDown?: () => void,
-    filterValue?: string
+    maxRows?: number
 }
 
 export const TextArea: React.FunctionComponent<TextAreaProps> = (props) => {
     if (props.readOnly) {
         return <ReadOnlyField
+            widgetName={props.widgetName}
+            meta={props.meta}
             className={props.className}
             backgroundColor={props.backgroundColor}
             onDrillDown={props.onDrillDown}
         >
-            {props.filterValue
-                ? <SearchHighlight
-                    source={(props.defaultValue || '').toString()}
-                    search={escapedSrc(props.filterValue)}
-                    match={formatString => <b>{formatString}</b>}/>
-                : props.defaultValue}
+            {props.defaultValue}
         </ReadOnlyField>
     }
 

--- a/src/components/ui/TextArea/TextArea.tsx
+++ b/src/components/ui/TextArea/TextArea.tsx
@@ -8,6 +8,8 @@ import InputDefaultClass from 'antd/lib/input/TextArea'
 import styles from './TextArea.less'
 import ReadOnlyField from '../ReadOnlyField/ReadOnlyField'
 import {TextAreaProps as AntdTextAreaProps} from 'antd/lib/input/TextArea'
+import SearchHighlight from '../SearchHightlight/SearchHightlight'
+import {escapedSrc} from '../../../utils/strings'
 
 type AdditionalAntdTextAreaProps = Partial<Omit<AntdTextAreaProps, 'onChange'>>
 export interface TextAreaProps extends AdditionalAntdTextAreaProps {
@@ -22,7 +24,8 @@ export interface TextAreaProps extends AdditionalAntdTextAreaProps {
     maxRows?: number,
     className?: string,
     backgroundColor?: string,
-    onDrillDown?: () => void
+    onDrillDown?: () => void,
+    filterValue?: string
 }
 
 export const TextArea: React.FunctionComponent<TextAreaProps> = (props) => {
@@ -32,7 +35,12 @@ export const TextArea: React.FunctionComponent<TextAreaProps> = (props) => {
             backgroundColor={props.backgroundColor}
             onDrillDown={props.onDrillDown}
         >
-            {props.defaultValue}
+            {props.filterValue
+                ? <SearchHighlight
+                    source={(props.defaultValue || '').toString()}
+                    search={escapedSrc(props.filterValue)}
+                    match={formatString => <b>{formatString}</b>}/>
+                : props.defaultValue}
         </ReadOnlyField>
     }
 

--- a/src/components/widgets/AssocListPopup/AssocListPopup.test.tsx
+++ b/src/components/widgets/AssocListPopup/AssocListPopup.test.tsx
@@ -2,9 +2,34 @@ import React from 'react'
 import {AssocListPopup, IAssocListActions, IAssocListProps} from './AssocListPopup'
 import {WidgetTypes} from 'interfaces/widget'
 import {FieldType} from 'interfaces/view'
-import {shallow} from 'enzyme'
+import {Provider} from 'react-redux'
+import {Store} from 'redux'
+import {Store as CoreStore} from '../../../interfaces/store'
+import {mockStore} from '../../../tests/mockStore'
+import * as redux from 'react-redux'
+import {mount} from 'enzyme'
+import {Modal} from 'antd'
 
 describe('AssocListPopup test', () => {
+    let store: Store<CoreStore> = null
+    const dispatch = jest.fn()
+
+    beforeAll(() => {
+        store = mockStore()
+    })
+
+    beforeEach(() => {
+        jest.spyOn(redux, 'useDispatch').mockImplementation(() => {
+            return dispatch
+        })
+    })
+
+    afterEach(() => {
+        dispatch.mockClear()
+        jest.resetAllMocks()
+        store.getState().view.pickMap = null
+    })
+
     const defProps: IAssocListProps = {
         widget: {
             name: 'UserPopup',
@@ -46,9 +71,12 @@ describe('AssocListPopup test', () => {
     }
 
     it('should render default title, table and footer', () => {
-        const wrapper = shallow(<AssocListPopup {...defProps} {...actionProps}/>)
-        expect(wrapper.props().title).toEqual(defProps.widget.title)
-        expect(wrapper.props().footer).toEqual(undefined)
+        const wrapper = mount(
+            <Provider store={store}>
+                <AssocListPopup {...defProps} {...actionProps}/>
+            </Provider>)
+        expect(wrapper.find(AssocListPopup).props().widget.title).toEqual(defProps.widget.title)
+        expect(wrapper.find(AssocListPopup).props().footer).toEqual(undefined)
         expect(wrapper.find('Connect(AssocTable)').length).toEqual(1)
     })
 
@@ -58,17 +86,20 @@ describe('AssocListPopup test', () => {
         const customTable = <p>{customTableText}</p>
         const customFooterText = 'custom Footer'
         const customFooter = <i>{customFooterText}</i>
-        const wrapper = shallow(<AssocListPopup
-            {...defProps}
-            {...actionProps}
-            components={{
-                title: customTitle,
-                table: customTable,
-                footer: customFooter
-            }}
-        />)
-        expect(wrapper.props().title).toEqual(customTitle)
-        expect(wrapper.props().footer).toEqual(customFooter)
-        expect(shallow(wrapper.props().children).text()).toEqual(customTableText)
+        const wrapper = mount(
+            <Provider store={store}>
+                <AssocListPopup
+                    {...defProps}
+                    {...actionProps}
+                    components={{
+                        title: customTitle,
+                        table: customTable,
+                        footer: customFooter
+                    }}
+                />
+            </Provider>)
+        expect(wrapper.find(AssocListPopup).children().props().title).toEqual(customTitle)
+        expect(wrapper.find(Modal).props().footer).toEqual(customFooter)
+        expect(wrapper.find('p').children().text()).toBe(customTableText)
     })
 })

--- a/src/components/widgets/AssocListPopup/AssocListPopup.tsx
+++ b/src/components/widgets/AssocListPopup/AssocListPopup.tsx
@@ -1,5 +1,5 @@
 import React, {FunctionComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, useSelector} from 'react-redux'
 import {$do} from '../../../actions/actions'
 import {DataItem, DataValue, PendingDataItem} from '../../../interfaces/data'
 import {Store} from '../../../interfaces/store'
@@ -59,7 +59,8 @@ export interface IAssocListProps extends IAssocListOwnProps {
     data?: AssociatedItem[],
     bcFilters?: BcFilter[],
     isFilter?: boolean,
-    calleeBCName?: string
+    calleeBCName?: string,
+    calleeWidgetName?: string
 }
 
 const emptyData: AssociatedItem[] = []
@@ -89,6 +90,7 @@ export const AssocListPopup: FunctionComponent<IAssocListProps & IAssocListActio
         pendingDataChanges,
         isFilter,
         calleeBCName,
+        calleeWidgetName,
         ...rest
     } = props
 
@@ -103,6 +105,9 @@ export const AssocListPopup: FunctionComponent<IAssocListProps & IAssocListActio
         onClose()
     }, [onSave, onClose])
 
+    const viewName = useSelector((store: Store) => {
+        return store.view.name
+    })
 
     const filterData = React.useCallback(() => {
         const filterValue = selectedRecords
@@ -111,7 +116,9 @@ export const AssocListPopup: FunctionComponent<IAssocListProps & IAssocListActio
             onFilter(props.calleeBCName, {
                 type: FilterType.equalsOneOf,
                 fieldName: props.associateFieldKey,
-                value: filterValue
+                value: filterValue,
+                viewName,
+                widgetName: props.calleeWidgetName
             })
         } else {
             const currentFilters = bcFilters?.find(filterItem => filterItem.fieldName === props.associateFieldKey)?.value
@@ -233,6 +240,7 @@ function mapStateToProps(store: Store, ownProps: IAssocListOwnProps) {
     const bc = store.screen.bo.bc[bcName]
     const isFilter = store.view.popupData.isFilter
     const calleeBCName = store.view.popupData.calleeBCName
+    const calleeWidgetName = store.view.popupData.calleeWidgetName
     const associateFieldKey = store.view.popupData.associateFieldKey
     const data = store.data[bcName] || emptyData
     const bcFilters = store.screen.filters?.[calleeBCName]
@@ -253,7 +261,8 @@ function mapStateToProps(store: Store, ownProps: IAssocListOwnProps) {
         data: data,
         bcFilters,
         isFilter,
-        calleeBCName
+        calleeBCName,
+        calleeWidgetName
     }
 }
 

--- a/src/components/widgets/TableWidget/TableWidget.test.tsx
+++ b/src/components/widgets/TableWidget/TableWidget.test.tsx
@@ -1,5 +1,5 @@
 import React, {ReactElement} from 'react'
-import {shallow} from 'enzyme'
+import {mount} from 'enzyme'
 import {TableWidget, TableWidgetProps} from './TableWidget'
 import {WidgetTableMeta, WidgetTypes} from 'interfaces/widget'
 import {FieldType} from 'interfaces/view'
@@ -8,8 +8,32 @@ import {RowMetaField} from 'interfaces/rowMeta'
 import {BcFilter, FilterGroup} from 'interfaces/filters'
 import {RouteType} from 'interfaces/router'
 import {Table} from 'antd'
+import {Store} from 'redux'
+import {Store as CoreStore} from '../../../interfaces/store'
+import {mockStore} from '../../../tests/mockStore'
+import * as redux from 'react-redux'
+import {Provider} from 'react-redux'
 
 describe('TableWidget test', () => {
+    let store: Store<CoreStore> = null
+    const dispatch = jest.fn()
+
+    beforeAll(() => {
+        store = mockStore()
+    })
+
+    beforeEach(() => {
+        jest.spyOn(redux, 'useDispatch').mockImplementation(() => {
+            return dispatch
+        })
+    })
+
+    afterEach(() => {
+        dispatch.mockClear()
+        jest.resetAllMocks()
+        store.getState().view.pickMap = null
+    })
+
     const hideFieldProps: WidgetTableMeta = {
         name: 'widgetName',
         title: 'wTitle',
@@ -66,25 +90,34 @@ describe('TableWidget test', () => {
     }
 
     it('should hide "hidden": true fields', () => {
-        const wrapper = shallow(<TableWidget
-            {...restProps}
-            meta={{...hideFieldProps}}
-        />)
+        const wrapper = mount(
+            <Provider store={store}>
+                <TableWidget
+                    {...restProps}
+                    meta={{...hideFieldProps}}
+                />
+            </Provider>)
         expect(wrapper.find(Table).length).toEqual(1)
         expect(wrapper.find(Table).props().columns.length).toEqual(1)
     })
 
     it('should render custom column title', () => {
         const customTitleText = 'Some title'
-        const wrapper1 = shallow(<TableWidget
-            {...restProps}
-            meta={{...hideFieldProps}}
-        />)
-        const wrapper = shallow(<TableWidget
-            {...restProps}
-            meta={{...hideFieldProps}}
-            columnTitleComponent={() => <div>{customTitleText}</div>}
-        />)
+        const wrapper1 = mount(
+            <Provider store={store}>
+                <TableWidget
+                    {...restProps}
+                    meta={{...hideFieldProps}}
+                />
+            </Provider>)
+        const wrapper = mount(
+            <Provider store={store}>
+                <TableWidget
+                    {...restProps}
+                    meta={{...hideFieldProps}}
+                    columnTitleComponent={() => <div>{customTitleText}</div>}
+                />
+            </Provider>)
         expect(wrapper.find(Table).props().columns.findIndex(i => (i.title as ReactElement).props.children === customTitleText)).toEqual(0)
         expect(wrapper1.find(Table).props().columns.findIndex(
             i => (i.title as ReactElement).props.widgetName === hideFieldProps.name

--- a/src/components/widgets/TableWidget/TableWidget.test.tsx
+++ b/src/components/widgets/TableWidget/TableWidget.test.tsx
@@ -1,5 +1,5 @@
 import React, {ReactElement} from 'react'
-import {mount} from 'enzyme'
+import {shallow} from 'enzyme'
 import {TableWidget, TableWidgetProps} from './TableWidget'
 import {WidgetTableMeta, WidgetTypes} from 'interfaces/widget'
 import {FieldType} from 'interfaces/view'
@@ -8,32 +8,8 @@ import {RowMetaField} from 'interfaces/rowMeta'
 import {BcFilter, FilterGroup} from 'interfaces/filters'
 import {RouteType} from 'interfaces/router'
 import {Table} from 'antd'
-import {Store} from 'redux'
-import {Store as CoreStore} from '../../../interfaces/store'
-import {mockStore} from '../../../tests/mockStore'
-import * as redux from 'react-redux'
-import {Provider} from 'react-redux'
 
 describe('TableWidget test', () => {
-    let store: Store<CoreStore> = null
-    const dispatch = jest.fn()
-
-    beforeAll(() => {
-        store = mockStore()
-    })
-
-    beforeEach(() => {
-        jest.spyOn(redux, 'useDispatch').mockImplementation(() => {
-            return dispatch
-        })
-    })
-
-    afterEach(() => {
-        dispatch.mockClear()
-        jest.resetAllMocks()
-        store.getState().view.pickMap = null
-    })
-
     const hideFieldProps: WidgetTableMeta = {
         name: 'widgetName',
         title: 'wTitle',
@@ -90,34 +66,25 @@ describe('TableWidget test', () => {
     }
 
     it('should hide "hidden": true fields', () => {
-        const wrapper = mount(
-            <Provider store={store}>
-                <TableWidget
-                    {...restProps}
-                    meta={{...hideFieldProps}}
-                />
-            </Provider>)
+        const wrapper = shallow(<TableWidget
+            {...restProps}
+            meta={{...hideFieldProps}}
+        />)
         expect(wrapper.find(Table).length).toEqual(1)
         expect(wrapper.find(Table).props().columns.length).toEqual(1)
     })
 
     it('should render custom column title', () => {
         const customTitleText = 'Some title'
-        const wrapper1 = mount(
-            <Provider store={store}>
-                <TableWidget
-                    {...restProps}
-                    meta={{...hideFieldProps}}
-                />
-            </Provider>)
-        const wrapper = mount(
-            <Provider store={store}>
-                <TableWidget
-                    {...restProps}
-                    meta={{...hideFieldProps}}
-                    columnTitleComponent={() => <div>{customTitleText}</div>}
-                />
-            </Provider>)
+        const wrapper1 = shallow(<TableWidget
+            {...restProps}
+            meta={{...hideFieldProps}}
+        />)
+        const wrapper = shallow(<TableWidget
+            {...restProps}
+            meta={{...hideFieldProps}}
+            columnTitleComponent={() => <div>{customTitleText}</div>}
+        />)
         expect(wrapper.find(Table).props().columns.findIndex(i => (i.title as ReactElement).props.children === customTitleText)).toEqual(0)
         expect(wrapper1.find(Table).props().columns.findIndex(
             i => (i.title as ReactElement).props.widgetName === hideFieldProps.name

--- a/src/components/widgets/TableWidget/TableWidget.tsx
+++ b/src/components/widgets/TableWidget/TableWidget.tsx
@@ -1,5 +1,5 @@
 import React, {FunctionComponent} from 'react'
-import {connect} from 'react-redux'
+import {connect, useSelector} from 'react-redux'
 import {Dispatch} from 'redux'
 import {Dropdown, Icon, Menu, Skeleton, Table} from 'antd'
 import {ColumnProps, TableProps, TableRowSelection} from 'antd/es/table'
@@ -368,6 +368,10 @@ export const TableWidget: FunctionComponent<TableWidgetProps> = (props) => {
         props.onSelectCell(recordId, props.meta.name, fieldKey)
     }
 
+    const viewName = useSelector((store: Store) => {
+        return store.view?.name
+    })
+
     const columns: Array<ColumnProps<DataItem>> = React.useMemo(() => {
         return props.meta.fields
             .filter((item: WidgetListField) => item.type !== FieldType.hidden && !item.hidden)
@@ -386,9 +390,17 @@ export const TableWidget: FunctionComponent<TableWidgetProps> = (props) => {
                     width: item.width,
                     render: (text: string, dataItem: DataItem) => {
                         if (item.type === FieldType.multivalue) {
+                            const filterValueKey = props.filters
+                                ?.filter(filterItem => filterItem.widgetName === props.meta.name && filterItem.viewName === viewName)
+                                ?.find(filter => filter.fieldName === item.key)
+                                ?.value.toString()
+                            const filterValue = (dataItem[item.key] as MultivalueSingleValue[])
+                                ?.find(bcDataItem => filterValueKey?.split(',')?.includes(bcDataItem.id))
+                                ?.value.toString()
                             return <MultivalueHover
                                 data={(dataItem[item.key] || emptyMultivalue) as MultivalueSingleValue[]}
                                 displayedValue={item.displayedKey && dataItem[item.displayedKey]}
+                                filterValue={item.displayedKey && filterValueKey ? dataItem[item.displayedKey]?.toString() : filterValue}
                             />
                         }
 

--- a/src/components/widgets/TableWidget/TableWidget.tsx
+++ b/src/components/widgets/TableWidget/TableWidget.tsx
@@ -1,5 +1,5 @@
 import React, {FunctionComponent} from 'react'
-import {connect, useSelector} from 'react-redux'
+import {connect} from 'react-redux'
 import {Dispatch} from 'redux'
 import {Dropdown, Icon, Menu, Skeleton, Table} from 'antd'
 import {ColumnProps, TableProps, TableRowSelection} from 'antd/es/table'
@@ -368,10 +368,6 @@ export const TableWidget: FunctionComponent<TableWidgetProps> = (props) => {
         props.onSelectCell(recordId, props.meta.name, fieldKey)
     }
 
-    const viewName = useSelector((store: Store) => {
-        return store.view?.name
-    })
-
     const columns: Array<ColumnProps<DataItem>> = React.useMemo(() => {
         return props.meta.fields
             .filter((item: WidgetListField) => item.type !== FieldType.hidden && !item.hidden)
@@ -390,17 +386,9 @@ export const TableWidget: FunctionComponent<TableWidgetProps> = (props) => {
                     width: item.width,
                     render: (text: string, dataItem: DataItem) => {
                         if (item.type === FieldType.multivalue) {
-                            const filterValueKey = props.filters
-                                ?.filter(filterItem => filterItem.widgetName === props.meta.name && filterItem.viewName === viewName)
-                                ?.find(filter => filter.fieldName === item.key)
-                                ?.value.toString()
-                            const filterValue = (dataItem[item.key] as MultivalueSingleValue[])
-                                ?.find(bcDataItem => filterValueKey?.split(',')?.includes(bcDataItem.id))
-                                ?.value.toString()
                             return <MultivalueHover
                                 data={(dataItem[item.key] || emptyMultivalue) as MultivalueSingleValue[]}
                                 displayedValue={item.displayedKey && dataItem[item.displayedKey]}
-                                filterValue={item.displayedKey && filterValueKey ? dataItem[item.displayedKey]?.toString() : filterValue}
                             />
                         }
 

--- a/src/epics/router/drilldown.ts
+++ b/src/epics/router/drilldown.ts
@@ -81,9 +81,11 @@ export function drillDownImpl(
                     store.dispatch($do.bcRemoveAllFilters({ bcName }))
                 }
             })
+            const nextState = defaultParseLocation(parsePath(url))
+            const viewName = nextState.viewName
             // Apply each new filter
             Object.entries(newFilters).forEach(([ bcName, filterExpression ]) => {
-                const parsedFilters = parseFilters(filterExpression)
+                const parsedFilters = parseFilters(filterExpression).map(item => ({ ...item, viewName }))
                 parsedFilters?.forEach(filter => {
                     bcToUpdate[bcName] = true
                     store.dispatch($do.bcAddFilter({ bcName, filter }))
@@ -96,7 +98,6 @@ export function drillDownImpl(
                 bcToUpdate[bcName] = true
             })
             const prevState = state.router
-            const nextState = defaultParseLocation(parsePath(url))
             const willUpdateAnyway = shallowCompare(prevState, nextState, ['params']).length > 0
             // If screen or view is different all BC will update anyway so there is no need
             // to manually set them for update

--- a/src/hooks/useWidgetFilter.ts
+++ b/src/hooks/useWidgetFilter.ts
@@ -1,0 +1,33 @@
+import React from 'react'
+import {useSelector} from 'react-redux'
+import {Store} from '../interfaces/store'
+
+/**
+ * Get filters from the store for specific widget and field
+ *
+ * @param widgetName
+ * @param fieldKey
+ */
+export function useWidgetFilters(widgetName: string, fieldKey: string) {
+    return useSelector((store: Store) => {
+        const viewName = store.view.name
+        const widget = store.view.widgets.find(item => item.name === widgetName)
+        const filters = store.screen.filters[widget?.bcName]?.filter(item => {
+            let match = item.fieldName === fieldKey
+            if (item.viewName) {
+                match = match && item.viewName === viewName
+            }
+            if (item.widgetName) {
+                match = match && item.widgetName === widget.name
+            }
+            return match
+        })
+        return filters || []
+    })
+}
+
+export function useWidgetHighlightFilter(widgetName: string, fieldKey: string) {
+    const filters = useWidgetFilters(widgetName, fieldKey)
+    const filter = filters[0]
+    return React.useMemo(() => filter, [filters[0]])
+}

--- a/src/interfaces/filters.ts
+++ b/src/interfaces/filters.ts
@@ -16,7 +16,9 @@ export const enum FilterType {
 export interface BcFilter {
     type: FilterType,
     fieldName: string,
-    value: DataValue | DataValue[]
+    value: DataValue | DataValue[],
+    viewName?: string,
+    widgetName?: string
 }
 
 export interface BcSorter {


### PR DESCRIPTION
See #482

**SearchHighlight enhancement**

Expanded filter object interface `bcFilter`. This allows identify widget by which filter is applied. With this change, it became possible to exclude incorrect highlighting of filtered text in widgets without filters on same BC.

``` ts
export interface BcFilter {
    type: FilterType,
    fieldName: string,
    value: DataValue | DataValue[],
    viewName?: string,     // new field
    widgetName?: string    // new field
}
```


Added search highlighting in the following field types (only with `readOnly: true` flag):
- Dictionary
- Date like
- Multivalue
- Text

_NOTE1:_ `Multivalue` highlighting based on presence `displayedValue` key. If key is present dataItem has displayed string, then current field record is highlighted.
_NOTE1:_ If backend use `drillDown` with filter, then need to fix this responce url to new format for correct highlighting result