### PR TITLE
Cancelation of `data` and `row-meta` requests is added (#486)

### DIFF
--- a/src/utils/__tests__/cancelRequestEpic.test.ts
+++ b/src/utils/__tests__/cancelRequestEpic.test.ts
@@ -1,0 +1,63 @@
+import {Store} from 'redux'
+import {Store as CoreStore} from '../../interfaces/store'
+import {mockStore} from '../../tests/mockStore'
+import {cancelRequestEpic} from '../cancelRequestEpic'
+import {$do, types} from '../../actions/actions'
+import {ActionsObservable} from 'redux-observable'
+import {testEpic} from '../../tests/testEpic'
+
+const bcExample = {
+    name: 'bcExample',
+    parentName: null as string,
+    url: '',
+    cursor: null as string,
+    loading: false
+}
+
+describe('cancelRequestEpic test', () => {
+    let store: Store<CoreStore> = null
+
+    beforeAll(() => {
+        store = mockStore()
+        store.getState().screen.bo.bc.bcExample = bcExample
+    })
+
+    it('should return set epic', () => {
+        const action = $do.logout(null)
+        const epic = cancelRequestEpic(
+            ActionsObservable.of(action),
+            [types.logout],
+            () => null,
+            $do.bcFetchRowMetaFail({ bcName: bcExample.name }),
+            (item) => {return true}
+        )
+        testEpic(epic, result => {
+            expect(result.length).toEqual(1)
+            expect(result[0]).toEqual(expect.objectContaining({
+                type: types.bcFetchRowMetaFail,
+                payload: expect.objectContaining({
+                    bcName: bcExample.name
+                })
+            }))
+        })
+    })
+    it('should return set epic', () => {
+        const action = $do.logout(null)
+        const epic = cancelRequestEpic(
+            ActionsObservable.of(action),
+            [types.logout],
+            () => null,
+            $do.bcFetchRowMetaFail({ bcName: bcExample.name })
+        )
+        testEpic(epic, result => {
+            expect(result.length).toEqual(1)
+            expect(result[0]).toEqual(expect.objectContaining({
+                type: types.bcFetchRowMetaFail,
+                payload: expect.objectContaining({
+                    bcName: bcExample.name
+                })
+            }))
+        })
+    })
+})
+

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -103,10 +103,12 @@ function onErrorHook(error: AxiosError, callContext?: ApiCallContext) {
             }
         }
     } else {
-        const networkError = {
-            type: ApplicationErrorType.NetworkError,
+        if (!axios.isCancel(error)) {
+            const networkError = {
+                type: ApplicationErrorType.NetworkError,
+            }
+            getStoreInstance().dispatch($do.showViewError({error: networkError}))
         }
-        getStoreInstance().dispatch($do.showViewError({error: networkError}))
     }
     throw error
 }

--- a/src/utils/cancelRequestEpic.ts
+++ b/src/utils/cancelRequestEpic.ts
@@ -1,0 +1,29 @@
+import {ActionPayloadTypes, ActionsObservable, AnyAction, types} from '../actions/actions'
+import {Observable} from 'rxjs'
+
+/**
+ * Default list of action types which are triggers for request cancel
+ */
+export const cancelRequestActionTypes = [types.selectView, types.logout]
+
+/**
+ * Creator of request cancel epic
+ *
+ * @param action$ an observable input
+ * @param actionTypes list of action types which triggers cancel
+ * @param cancelFn a callback of request cancelation
+ * @param cancelActionCreator an action creator which called by request cancelation
+ * @param filterFn a callback function which filters come actions
+ */
+export function cancelRequestEpic(
+    action$: ActionsObservable<AnyAction>,
+    actionTypes: Array<keyof ActionPayloadTypes>,
+    cancelFn: () => void,
+    cancelActionCreator: AnyAction,
+    filterFn: (actions: AnyAction) => boolean = (item) => {return true}
+) {
+    return action$.ofType(...actionTypes).filter(filterFn).mergeMap(() => {
+        cancelFn()
+        return Observable.of(cancelActionCreator)
+    }).take(1)
+}


### PR DESCRIPTION
See #486 

There is added `createCanceler` utility. It returns new `axios.CancelToken` and callback function which performs request cancelation.

Also `cancelRequestEpic` is added. It's a utility epic.
It gets:
- an observable input
- list of action types which triggers cancel
- a callback of request cancelation
- an action creator which called by request cancelation
- Optional callback function which filters come actions

Returns an epic which cancels request and dispatches cancel action