### PR TITLE
console helper `scrollToItem` for automation testing of `<TreeVirtualized />` components

### DIFF
--- a/src/components/ui/TreeVirtualized/__tests__/TreeVirtualized.test.tsx
+++ b/src/components/ui/TreeVirtualized/__tests__/TreeVirtualized.test.tsx
@@ -17,7 +17,7 @@
 
 import React from 'react'
 import {mount} from 'enzyme'
-import {TreeVirtualized} from '../TreeVirtualized'
+import {TreeVirtualized, TreeVirtualizedDomContainer} from '../TreeVirtualized'
 import {TreeVirtualizedNode, TreeVirtualizedNodeProps} from '../TreeVirtualizedNode'
 import {act} from 'react-dom/test-utils'
 import {FilterType} from '../../../../interfaces/filters'
@@ -113,6 +113,27 @@ describe('<TreeVirtualized />', () => {
         expect(wrapper.find(TreeVirtualizedNode).at(0).text()).toBe('one')
         expect(wrapper.find(TreeVirtualizedNode).at(1).text()).toBe('two')
         expect(wrapper.find(TreeVirtualizedNode).at(2).text()).toBe('three')
+    })
+
+    it('provides `scrollToIndex` and `scrollToItem` helpers for Selenium tests', () => {
+        const largeSample = new Array(200).fill(null).map((item, index) => {
+            return { id: index.toString(), parentId: '0', level: 1 }
+        })
+        const wrapper = mount(<Provider store={store}>
+            <TreeVirtualized<typeof largeSample[number]>
+                items={largeSample}
+                width={640}
+                height={480}
+                itemSize={45}
+                fields={[{ key: 'name', title: '', type: FieldType.input }]}
+                onSelect={jest.fn}
+            />
+            </Provider>
+        )
+        const container = (wrapper.getDOMNode() as TreeVirtualizedDomContainer)
+        container.scrollToItem('50', 'id', 'start')
+        wrapper.update()
+        expect((wrapper.find(TreeVirtualizedNode).at(0).props() as any).index).toBe(48)
     })
 })
 

--- a/src/utils/tree.ts
+++ b/src/utils/tree.ts
@@ -109,7 +109,9 @@ export function presort(data: TreeNodeBidirectional[]) {
     const result: string[] = []
     data.filter(item => item.level === 1).forEach(item => {
         result.push(item.id)
-        getDescendants(item.children, result)
+        if (item.children) {
+            getDescendants(item.children, result)
+        }
     })
     return result.map(id => data.find(match => match.id === id))
 }


### PR DESCRIPTION
If `<TreeVirtualized />` has more items than fit into display window, it can be difficult to find required item with automation tests drivers such as Selenium.

This PR adds `scrollToItem` function to DOM element of `<TreeVirtualized />` component which can be called by JS executor from Selenium tests.