### PR TITLE
`showAssocPopup` epic will crash when Tesler API returns null instead of empty array, which it will for SQL BC

### DIFF
--- a/src/epics/view.ts
+++ b/src/epics/view.ts
@@ -217,7 +217,7 @@ const showAssocPopup: Epic = (action$, store) => action$.ofType(types.showViewPo
         })
 
         const calleeData = state.data[calleeBCName]?.find((dataRecord) => dataRecord.id === calleeCursor)
-        const assocIds = (calleeData?.[assocFieldKey] as MultivalueSingleValue[]).map((recordId) => recordId.id)
+        const assocIds = (calleeData?.[assocFieldKey] as MultivalueSingleValue[])?.map((recordId) => recordId.id)
         const assocPendingIds = assocFieldChanges.map((recordId) => recordId.id)
         if (assocIds) {
             assocIds.forEach((recordId) => {


### PR DESCRIPTION
Same as #536 without refactoring