### PR TITLE
FIX: useDrillDownUrl replace widgetName by bcName

### DIFF
--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -115,7 +115,7 @@ const emptyFieldMeta = [] as any
 export const Field: FunctionComponent<FieldProps> = (props) => {
     const [localValue, setLocalValue] = React.useState(null)
     let resultField: React.ReactChild = null
-    const drillDownUrl = useDrillDownUrl(props.widgetName, props.widgetFieldMeta, props.cursor)
+    const drillDownUrl = useDrillDownUrl(props.bcName, props.widgetFieldMeta, props.cursor)
 
     const value = ('forcedValue' in props)
         ? props.forcedValue
@@ -169,7 +169,7 @@ export const Field: FunctionComponent<FieldProps> = (props) => {
         placeholder,
         readOnly: props.readonly,
         backgroundColor: bgColor,
-        onDrillDown: handleDrilldown
+        onDrillDown: handleDrilldown,
     }
     const commonInputProps: any = {
         cursor: props.cursor,

--- a/src/components/ui/ReadOnlyField/ReadOnlyField.tsx
+++ b/src/components/ui/ReadOnlyField/ReadOnlyField.tsx
@@ -6,7 +6,6 @@ import {WidgetFieldBase} from '../../../interfaces/widget'
 import {useWidgetHighlightFilter} from '../../../hooks/useWidgetFilter'
 import SearchHighlight from '../SearchHightlight/SearchHightlight'
 import {escapedSrc} from '../../../utils/strings'
-import {useDrillDownUrl} from '../../../hooks/useDrillDownUrl'
 
 export interface ReadOnlyFieldProps {
     /**
@@ -26,7 +25,6 @@ export interface ReadOnlyFieldProps {
 
 const ReadOnlyField: React.FunctionComponent<ReadOnlyFieldProps> = (props) => {
     const filter = useWidgetHighlightFilter(props.widgetName, props.meta.key)
-    const drillDownUrl = useDrillDownUrl(props.widgetName, props.meta, props.cursor)
     const displayedValue = filter
         ? <SearchHighlight
             source={(props.children || '').toString()}
@@ -42,8 +40,7 @@ const ReadOnlyField: React.FunctionComponent<ReadOnlyFieldProps> = (props) => {
         )}
         style={props.backgroundColor ? { backgroundColor: props.backgroundColor } : null}
     >
-        {props.onDrillDown && drillDownUrl
-            ? <ActionLink onClick={props.onDrillDown}>
+        {props.onDrillDown ? <ActionLink onClick={props.onDrillDown}>
                 {displayedValue}
             </ActionLink>
             : displayedValue

--- a/src/hooks/useDrillDownUrl.ts
+++ b/src/hooks/useDrillDownUrl.ts
@@ -4,21 +4,17 @@ import {WidgetFieldBase} from '../interfaces/widget'
 import {buildBcUrl} from '../utils/strings'
 
 /**
- * @param widgetName - widget name passed to field
+ * @param bcName - bcName passed to field
  * @param cursor - field ID
  * @param fieldMeta - widget field meta
  * @description Allows to override drilldown url from field data by drillDownKey. Checking order allows to disable
  * drilldown link, for example if object is removed.
  */
-export function useDrillDownUrl(widgetName: string, fieldMeta: WidgetFieldBase, cursor: string): string | null {
+export function useDrillDownUrl(bcName: string, fieldMeta: WidgetFieldBase, cursor: string): string | null {
     const drillDownLink = useSelector((store: Store) => {
-        const widgetMeta = store.view.widgets.find((widget) => widget.name === widgetName)
-        if (!widgetMeta) {
-            return null
-        }
-        const record = store.data[widgetMeta.bcName]?.find(dataItem => dataItem.id === cursor)
-        const bcUrl = buildBcUrl(widgetMeta.bcName, true)
-        const rowMeta = bcUrl && store.view.rowMeta[widgetMeta.bcName]?.[bcUrl]
+        const record = store.data[bcName]?.find(dataItem => dataItem.id === cursor)
+        const bcUrl = buildBcUrl(bcName, true)
+        const rowMeta = bcUrl && store.view.rowMeta[bcName]?.[bcUrl]
         if (!rowMeta || !rowMeta.fields) {
             return null
         }


### PR DESCRIPTION
Removed useDrillDownUrl from ReadOnlyField, widgetName replaced by bcName for widgets with different bc