### PR TITLE
`requestBcChildren` utility moved to `utils/bc.ts`, test coverage

### DIFF
--- a/src/epics/data.ts
+++ b/src/epics/data.ts
@@ -22,7 +22,7 @@ import {bcCancelCreateDataEpic} from './data/bcCancelCreateDataEpic'
 import {bcNewDataEpic} from './data/bcNewDataEpic'
 import {bcFetchRowMetaRequest} from './data/bcFetchRowMetaRequest'
 import {selectView} from './data/selectView'
-import {requestBcChildren} from '../utils/bc'
+import {getBcChildren} from '../utils/bc'
 
 const maxDepthLevel = 10
 
@@ -147,7 +147,7 @@ const bcFetchDataEpic: Epic = (action$, store) => action$.ofType(
                         ignorePageLimit: true
                     }))
                     : Observable.empty<never>()
-                : Object.entries(requestBcChildren(bcName, state.view.widgets, state.screen.bo.bc))
+                : Object.entries(getBcChildren(bcName, state.view.widgets, state.screen.bo.bc))
                     .map(entry => {
                         const [childBcName, widgetNames] = entry
                         return $do.bcFetchDataRequest({
@@ -239,7 +239,7 @@ const bcSelectRecord: Epic = (action$, store) => action$.ofType(types.bcSelectRe
     const {bcName, cursor} = action.payload
     const widgets = store.getState().view.widgets
     const bcMap = store.getState().screen.bo.bc
-    const fetchChildrenBcData = Object.entries(requestBcChildren(bcName, widgets, bcMap))
+    const fetchChildrenBcData = Object.entries(getBcChildren(bcName, widgets, bcMap))
         .map(entry => {
             const [childBcName, widgetNames] = entry
             return $do.bcFetchDataRequest({
@@ -347,7 +347,7 @@ const bcSaveDataEpic: Epic = (action$, store) => action$.ofType(types.sendOperat
         }
     }
 
-    const fetchChildrenBcData = Object.entries(requestBcChildren(bcName, state.view.widgets, state.screen.bo.bc))
+    const fetchChildrenBcData = Object.entries(getBcChildren(bcName, state.view.widgets, state.screen.bo.bc))
     .map(entry => {
         const [childBcName, widgetNames] = entry
         return $do.bcFetchDataRequest({ bcName: childBcName, widgetName: widgetNames[0] })

--- a/src/utils/__tests__/bc.test.ts
+++ b/src/utils/__tests__/bc.test.ts
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-import {requestBcChildren} from '../bc'
+import {getBcChildren} from '../bc'
 import {WidgetTypes, WidgetTableMeta} from '../../interfaces/widget'
 
 describe('requestBcChildren', () => {
     it('returns all direct children for specified bc and all descendant widgets', () => {
-        expect(requestBcChildren('bcExample-1', widgets, bcMap))
+        expect(getBcChildren('bcExample-1', widgets, bcMap))
         .toEqual(expect.objectContaining({
             'bcExample-1-1': [
                 'widget-example-1-1-1',
@@ -36,11 +36,15 @@ describe('requestBcChildren', () => {
     })
 
     it('handles hierarchy widgets', () => {
-        expect(requestBcChildren('bcHierarchy-1', [getHierarchyWidget()], bcHierarchyMap))
+        expect(getBcChildren(
+            'bcHierarchy-1',
+            [getHierarchyWidget(), { ...getHierarchyWidget(), bcName: 'bcHierarchy-0' }],
+            bcHierarchyMap
+        ))
         .toEqual(expect.objectContaining({
             'bcHierarchy-2': ['widget-hierarchy']
         }))
-        expect(requestBcChildren('bcHierarchy-2', [getHierarchyWidget()], bcHierarchyMap))
+        expect(getBcChildren('bcHierarchy-2', [getHierarchyWidget()], bcHierarchyMap))
         .toEqual(expect.objectContaining({
             'bcHierarchy-3': ['widget-hierarchy']
         }))
@@ -48,7 +52,7 @@ describe('requestBcChildren', () => {
     })
 
     it('handles weird case when first level of hierarchy does not specifies bc', () => {
-        expect(requestBcChildren('bcHierarchy-1', [getHierarchyWidget(true)], bcHierarchyMap))
+        expect(getBcChildren('bcHierarchy-1', [getHierarchyWidget(true)], bcHierarchyMap))
         .toEqual({})
     })
 
@@ -66,7 +70,7 @@ describe('requestBcChildren', () => {
                 url: 'bcHierarchy-2/:id'
             }
         }
-        expect(requestBcChildren('bcHierarchy-1', sameWidgets, sameMap))
+        expect(getBcChildren('bcHierarchy-1', sameWidgets, sameMap))
         .toEqual(expect.objectContaining({
             'bcHierarchy-2': ['widget-example-same', 'widget-hierarchy']
         }))
@@ -179,6 +183,11 @@ const bcMap = {
 }
 
 const bcHierarchyMap = {
+    'bcHierarchy-0': {
+        ...bcExample,
+        name: 'bcHierarchy-0',
+        url: 'bcHierarchy-0/:id'
+    },
     'bcHierarchy-1': {
         ...bcExample,
         name: 'bcHierarchy-1',

--- a/src/utils/__tests__/bc.test.ts
+++ b/src/utils/__tests__/bc.test.ts
@@ -1,0 +1,187 @@
+/*
+ * TESLER-UI
+ * Copyright (C) 2018-2021 Tesler Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {requestBcChildren} from '../bc'
+import {WidgetTypes, WidgetTableMeta} from '../../interfaces/widget'
+
+describe('requestBcChildren', () => {
+    it('returns all direct children for specified bc and all descendant widgets', () => {
+        expect(requestBcChildren('bcExample-1', widgets, bcMap))
+        .toEqual(expect.objectContaining({
+            'bcExample-1-1': [
+                'widget-example-1-1-1',
+                'widget-example-1-1-2',
+                'widget-example-1-1-3',
+                'widget-example-1-1',
+            ],
+            'bcExample-1-2': [
+                'widget-example-1-2-1',
+                'widget-example-1-2'
+            ]
+        }))
+    })
+
+    it('handles hierarchy widgets', () => {
+        expect(requestBcChildren('bcHierarchy-1', [getHierarchyWidget()], bcHierarchyMap))
+        .toEqual(expect.objectContaining({
+            'bcHierarchy-2': ['widget-hierarchy']
+        }))
+        expect(requestBcChildren('bcHierarchy-2', [getHierarchyWidget()], bcHierarchyMap))
+        .toEqual(expect.objectContaining({
+            'bcHierarchy-3': ['widget-hierarchy']
+        }))
+
+    })
+
+    it('handles weird case when first level of hierarchy does not specifies bc', () => {
+        expect(requestBcChildren('bcHierarchy-1', [getHierarchyWidget(true)], bcHierarchyMap))
+        .toEqual({})
+    })
+
+    it('handles case when hierarchy level references BC used by non-hierarchy widget', () => {
+        const sameWidgets = [
+            { ...getWidgetMeta(), name: 'widget-example-same', bcName: 'bcHierarchy-2' },
+            getHierarchyWidget()
+        ]
+        const sameMap = {
+            ...bcHierarchyMap,
+            'bcHierarchy-2': {
+                ...bcExample,
+                name: 'bcHierarchy-2',
+                parentName: 'bcHierarchy-1',
+                url: 'bcHierarchy-2/:id'
+            }
+        }
+        expect(requestBcChildren('bcHierarchy-1', sameWidgets, sameMap))
+        .toEqual(expect.objectContaining({
+            'bcHierarchy-2': ['widget-example-same', 'widget-hierarchy']
+        }))
+    })
+
+})
+
+function getWidgetMeta(): WidgetTableMeta {
+    return {
+        name: 'widget-example',
+        type: WidgetTypes.List,
+        title: null,
+        bcName: 'bcExample',
+        position: 1,
+        gridWidth: null,
+        fields: []
+    }
+}
+
+const widgets: WidgetTableMeta[] = [
+    { ...getWidgetMeta(), name: 'widget-example-1-1-1', bcName: 'bcExample-1-1-1' },
+    { ...getWidgetMeta(), name: 'widget-example-1-1-2', bcName: 'bcExample-1-1-2' },
+    { ...getWidgetMeta(), name: 'widget-example-1-1-3', bcName: 'bcExample-1-1-3' },
+    { ...getWidgetMeta(), name: 'widget-example-1-2-1', bcName: 'bcExample-1-2-1' },
+    { ...getWidgetMeta(), name: 'widget-example-1-1', bcName: 'bcExample-1-1' },
+    { ...getWidgetMeta(), name: 'widget-example-1-2', bcName: 'bcExample-1-2' },
+    { ...getWidgetMeta(), name: 'widget-example-1', bcName: 'bcExample-1' },
+    { ...getWidgetMeta(), name: 'widget-example-2', bcName: 'bcExample-2' },
+    { ...getWidgetMeta(), name: 'widget-example-2-1', bcName: 'bcExample-2-1' }
+]
+
+function getHierarchyWidget(missingBc?: boolean): WidgetTableMeta {
+    return {
+        ...getWidgetMeta(),
+        name: 'widget-hierarchy',
+        bcName: 'bcHierarchy-1',
+        options: {
+            hierarchy: [
+                { bcName: missingBc ? null : 'bcHierarchy-2', fields: [] },
+                { bcName: 'bcHierarchy-3', fields: [] },
+                { bcName: 'bcHierarchy-4', fields: [] }
+            ]
+        }
+    }
+}
+
+const bcExample = {
+    name: 'bcExample',
+    parentName: null as string,
+    url: 'bcExample/:id',
+    cursor: '1',
+    page: 2,
+    limit: 5,
+    loading: false
+}
+
+const bcMap = {
+    'bcExample-1-1-1': {
+        ...bcExample,
+        name: 'bcExample-1-1-1',
+        parentName: 'bcExample-1-1',
+        url: 'bcExample-1/:id/bcExample-1-1/:id/bcExample-1-1-1/:id'
+    },
+    'bcExample-1-1-2': {
+        ...bcExample,
+        name: 'bcExample-1-1-2',
+        parentName: 'bcExample-1-1',
+        url: 'bcExample-1/:id/bcExample-1-1/:id/bcExample-1-1-2/:id'
+    },
+    'bcExample-1-1-3': {
+        ...bcExample,
+        name: 'bcExample-1-1-3',
+        parentName: 'bcExample-1-1',
+        url: 'bcExample-1/:id/bcExample-1-1/:id/bcExample-1-1-3/:id'
+    },
+    'bcExample-1-1': {
+        ...bcExample,
+        name: 'bcExample-1-1',
+        parentName: 'bcExample-1',
+        url: 'bcExample-1/:id/bcExample-1-1/:id'
+    },
+    'bcExample-1-2': {
+        ...bcExample,
+        name: 'bcExample-1-2',
+        parentName: 'bcExample-1',
+        url: 'bcExample-1/:id/bcExample-1-2/:id'
+    },
+    'bcExample-1-2-1': {
+        ...bcExample,
+        name: 'bcExample-1-2-1',
+        parentName: 'bcExample-1-2',
+        url: 'bcExample-1/:id/bcExample-1-2/:id/bcExample-1-2-1/:id'
+    },
+    'bcExample-1': {
+        ...bcExample,
+        name: 'bcExample-1',
+        url: 'bcExample-1/:id'
+    },
+    'bcExample-2': {
+        ...bcExample,
+        name: 'bcExample-2',
+        url: 'bcExample-2/:id'
+    },
+    'bcExample-2-1': {
+        ...bcExample,
+        name: 'bcExample-2-1',
+        parentName: 'bcExample-2',
+        url: 'bcExample-2/:id/bcExample-2-1/:id'
+    }
+}
+
+const bcHierarchyMap = {
+    'bcHierarchy-1': {
+        ...bcExample,
+        name: 'bcHierarchy-1',
+        url: 'bcHierarchy-1/:id'
+    }
+}

--- a/src/utils/bc.ts
+++ b/src/utils/bc.ts
@@ -1,0 +1,83 @@
+/*
+ * TESLER-UI
+ * Copyright (C) 2018-2020 Tesler Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {WidgetTableMeta, WidgetMeta} from '../interfaces/widget'
+import {BcMetaState} from '../interfaces/bc'
+
+/**
+ * Find all widgets referencing or descendant from specified origin BC
+ *
+ * @param originBcName Parent business component name
+ * @param widgets Widgets to search through
+ * @param bcMap Business components dictionary
+ * @returns A dictionary of business components and widgets
+ */
+export function requestBcChildren(
+    originBcName: string,
+    widgets: WidgetMeta[],
+    bcMap: Record<string, BcMetaState>
+) {
+    // Build a dictionary with children for requested BC and widgets that need this BC
+    const childrenBcMap: Record<string, string[]> = {}
+    widgets.forEach(widget => {
+        if (widget.bcName) {
+            const widgetBcList: string[] = []
+
+            widgetBcList.push(widget.bcName)
+            let parentName = bcMap[widget.bcName]?.parentName
+            while (parentName) {
+                widgetBcList.push(parentName)
+                parentName = bcMap[parentName]?.parentName
+            }
+
+            widgetBcList.some((expectedBcName) => {
+                if (bcMap[expectedBcName].parentName === originBcName) {
+                    if (!childrenBcMap[expectedBcName]) {
+                        childrenBcMap[expectedBcName] = []
+                    }
+                    childrenBcMap[expectedBcName].push(widget.name)
+                    return true
+                }
+
+                return false
+            })
+        }
+    })
+
+    // If widgets supports hierarchy, try to find children though it
+    // TODO: need description and split to separate methods?
+    const hierarchyWidget = widgets.find(item => {
+        const hierarchy = item.options?.hierarchy
+        const nestedBc = hierarchy?.map(nestedItem => nestedItem.bcName)
+        return hierarchy && (item.bcName === originBcName || nestedBc.includes(originBcName))
+    }) as WidgetTableMeta
+    if (hierarchyWidget) {
+        const nestedBcNames = hierarchyWidget.options?.hierarchy.map(nestedItem => nestedItem.bcName)
+        const childHierarchyBcIndex = nestedBcNames.findIndex(item => item === originBcName)
+        const childHierarchyBcName = childHierarchyBcIndex !== -1
+            ? nestedBcNames[childHierarchyBcIndex + 1]
+            : hierarchyWidget.options?.hierarchy[0].bcName
+        if (!childHierarchyBcName) {
+            return childrenBcMap
+        }
+        if (!childrenBcMap[childHierarchyBcName]) {
+            childrenBcMap[childHierarchyBcName] = []
+        }
+        childrenBcMap[childHierarchyBcName].push(hierarchyWidget.name)
+    }
+    return childrenBcMap
+}

--- a/src/utils/bc.ts
+++ b/src/utils/bc.ts
@@ -1,6 +1,6 @@
 /*
  * TESLER-UI
- * Copyright (C) 2018-2020 Tesler Contributors
+ * Copyright (C) 2018-2021 Tesler Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,69 +15,65 @@
  * limitations under the License.
  */
 
-import {WidgetTableMeta, WidgetMeta} from '../interfaces/widget'
+import {WidgetMeta} from '../interfaces/widget'
 import {BcMetaState} from '../interfaces/bc'
 
 /**
  * Find all widgets referencing or descendant from specified origin BC
  *
- * @param originBcName Parent business component name
+ * @param originBcName Origin business component name
  * @param widgets Widgets to search through
  * @param bcMap Business components dictionary
  * @returns A dictionary of business components and widgets
  */
-export function requestBcChildren(
+export function getBcChildren(
     originBcName: string,
     widgets: WidgetMeta[],
     bcMap: Record<string, BcMetaState>
 ) {
     // Build a dictionary with children for requested BC and widgets that need this BC
     const childrenBcMap: Record<string, string[]> = {}
-    widgets.forEach(widget => {
-        if (widget.bcName) {
-            const widgetBcList: string[] = []
-
-            widgetBcList.push(widget.bcName)
-            let parentName = bcMap[widget.bcName]?.parentName
-            while (parentName) {
-                widgetBcList.push(parentName)
-                parentName = bcMap[parentName]?.parentName
-            }
-
-            widgetBcList.some((expectedBcName) => {
-                if (bcMap[expectedBcName].parentName === originBcName) {
-                    if (!childrenBcMap[expectedBcName]) {
-                        childrenBcMap[expectedBcName] = []
-                    }
-                    childrenBcMap[expectedBcName].push(widget.name)
-                    return true
-                }
-
-                return false
-            })
+    widgets
+    .filter(widget => widget.bcName)
+    .forEach(widget => {
+        const widgetBcList: string[] = []
+        // Find all BC ancestors for widget
+        widgetBcList.push(widget.bcName)
+        let parentName = bcMap[widget.bcName].parentName
+        while (parentName) {
+            widgetBcList.push(parentName)
+            parentName = bcMap[parentName].parentName
+        }
+        // Put all widgets referencing this BC ancestors in dictionary
+        widgetBcList
+        .filter(expectedBcName => bcMap[expectedBcName].parentName === originBcName)
+        .forEach(expectedBcName => {
+            childrenBcMap[expectedBcName] = [ ...(childrenBcMap[expectedBcName] || []), widget.name ]
+        })
+    })
+    // If widget supports hierarchy, try to find origin BC in hierarchy options
+    widgets.filter(item => item.options?.hierarchy).forEach(widget => {
+        const [hierarchyBcName, hierarchyWidgetName] = getHierarchyChildBc(originBcName, widget)
+        if (hierarchyBcName) {
+            childrenBcMap[hierarchyBcName] = [ ...(childrenBcMap[hierarchyBcName] || []), hierarchyWidgetName ]
         }
     })
 
-    // If widgets supports hierarchy, try to find children though it
-    // TODO: need description and split to separate methods?
-    const hierarchyWidget = widgets.find(item => {
-        const hierarchy = item.options?.hierarchy
-        const nestedBc = hierarchy?.map(nestedItem => nestedItem.bcName)
-        return hierarchy && (item.bcName === originBcName || nestedBc.includes(originBcName))
-    }) as WidgetTableMeta
-    if (hierarchyWidget) {
-        const nestedBcNames = hierarchyWidget.options?.hierarchy.map(nestedItem => nestedItem.bcName)
-        const childHierarchyBcIndex = nestedBcNames.findIndex(item => item === originBcName)
-        const childHierarchyBcName = childHierarchyBcIndex !== -1
-            ? nestedBcNames[childHierarchyBcIndex + 1]
-            : hierarchyWidget.options?.hierarchy[0].bcName
-        if (!childHierarchyBcName) {
-            return childrenBcMap
-        }
-        if (!childrenBcMap[childHierarchyBcName]) {
-            childrenBcMap[childHierarchyBcName] = []
-        }
-        childrenBcMap[childHierarchyBcName].push(hierarchyWidget.name)
-    }
     return childrenBcMap
+}
+
+/**
+ * Find child bc for hierarchy widget
+ *
+ * @param originBcName Origin business component name
+ * @param hierarchyWidget Hierarchy widget
+ */
+function getHierarchyChildBc(originBcName: string, hierarchyWidget: WidgetMeta) {
+    const nestedBcNames = hierarchyWidget.options.hierarchy.map(nestedItem => nestedItem.bcName)
+    if (originBcName !== hierarchyWidget.bcName && !nestedBcNames.includes(originBcName)) {
+        return []
+    }
+    const childHierarchyBcIndex = nestedBcNames.findIndex(item => item === originBcName)
+    const childHierarchyBcName = nestedBcNames[childHierarchyBcIndex + 1]
+    return [childHierarchyBcName, hierarchyWidget.name]
 }


### PR DESCRIPTION
* `requestBcChildren` utility moved to `utils/bc.ts` and renamed to `getBcChildren`
* test coverage for this utility
* contract changed to accept widgets and BC dictionary instead of accessing global store instance
* implementation refactored: hierarchy logic split into separate function, simplified code, optional chaining removed when it was not working (never hit due to outer condition check or neighboring code accessing the same properties without chaining) 