### PR TITLE
Full hierarchy column sizes fix

### DIFF
--- a/src/components/FullHierarchyTable/FullHierarchyTable.less
+++ b/src/components/FullHierarchyTable/FullHierarchyTable.less
@@ -8,9 +8,11 @@
 }
 
 .table {
-    table-layout: fixed;
-
     :global {
+        .ant-table-body > table {
+            table-layout: fixed;
+        }
+
         .ant-table .ant-table-thead > tr > th.ant-table-column-has-actions.ant-table-column-has-filters {
             .ant-table-filter-icon.ant-table-filter-open {
                 background: #fbfeff;

--- a/src/components/FullHierarchyTable/FullHierarchyTable.tsx
+++ b/src/components/FullHierarchyTable/FullHierarchyTable.tsx
@@ -197,16 +197,18 @@ export const FullHierarchyTable: React.FunctionComponent<FullHierarchyTableAllPr
     }
 
     // Hierarchy levels are indented by empty columns with calculated width
-    const indentColumn = {
-        title: '',
-        key: '_indentColumn',
-        dataIndex: null as string,
-        className: cn(styles.selectColumn, styles[`padding${depthLevel - 1}`]),
-        width: getColumnWidth('_indentColumn', depthLevel, fields, props.rowMetaFields, maxDepth),
-        render: (text: string, dataItem: AssociatedItem): React.ReactNode => {
-            return null
+    const indentColumn = React.useMemo(() => {
+        return {
+            title: '',
+            key: '_indentColumn',
+            dataIndex: null as string,
+            className: cn(styles.selectColumn, styles[`padding${depthLevel - 1}`]),
+            width: getColumnWidth('_indentColumn', depthLevel, fields, props.rowMetaFields, maxDepth),
+            render: (text: string, dataItem: AssociatedItem): React.ReactNode => {
+                return null
+            }
         }
-    }
+    }, [depthLevel, fields, props.rowMetaFields, maxDepth])
 
     const columns: Array<ColumnProps<DataItem>> = React.useMemo(() => {
         return [
@@ -249,7 +251,7 @@ export const FullHierarchyTable: React.FunctionComponent<FullHierarchyTableAllPr
                     }
                 }))
         ]
-    }, [depthLevel, fields, props.meta.name, textFilters])
+    }, [depthLevel, fields, props.meta.name, textFilters, indentColumn])
 
     const handleRow = React.useCallback((record: ChildrenAwaredHierarchyItem, index: number) => {
         if (hierarchyDisableRoot && depthLevel === 1) {


### PR DESCRIPTION
In full hierarchy tables **table-layout: fixed** style was applied to table **\<div/>** container instead of **\<table/>** itself, that caused inconsistency in separate inner table sizes.