### PR TITLE
`handleRouter` epic tests

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -851,10 +851,17 @@ export class ActionPayloadTypes {
     } = z
 
     /**
-     * TODO
+     * For server side routing where {@link RouteType.router | routes are handled by Tesler API endpoint}, this action is dispatched
+     * to process requested route.
      */
     handleRouter: {
+        /**
+         * An URL that will be passed to Tesler API router endpoint
+         */
         path: string
+        /**
+         * AJAX request parameters for the requests
+         */
         params: Record<string, unknown>
     } = z
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -17,14 +17,13 @@
 
 import { applyParams, applyRawParams, axiosDelete, axiosGet, axiosPost, axiosPut, ApiCallContext } from '../utils/api'
 import { buildUrl } from '../utils/history'
-import { ObjectMap } from '../interfaces/objectMap'
 import { BcDataResponse, DataItem, DataItemResponse, PendingDataItem } from '../interfaces/data'
 import { RowMetaResponse } from '../interfaces/rowMeta'
 import { AssociatedItem } from '../interfaces/operation'
 import { Observable } from 'rxjs/Observable'
 import axios, { CancelToken } from 'axios'
 
-type GetParamsMap = ObjectMap<string | number>
+type GetParamsMap = Record<string, string | number>
 
 /**
  * TODO

--- a/src/epics/router.ts
+++ b/src/epics/router.ts
@@ -28,6 +28,7 @@ import { changeLocation } from './router/changeLocation'
 import { changeScreen } from './router/selectScreen'
 import { changeView } from './router/selectView'
 import { loginDone } from './router/loginDone'
+import { handleRouter } from './router/handleRouter'
 
 /**
  *
@@ -81,28 +82,6 @@ export const userDrillDown: Epic = (action$, store) =>
                     return Observable.empty() // TODO:
                 })
         })
-
-/**
- *
- * @param action$
- * @param store
- * @category Epics
- */
-export const handleRouter: Epic = (action$, store) =>
-    action$.ofType(types.handleRouter).switchMap(action => {
-        const path = action.payload.path
-        const params = action.payload.params
-        // todo: Обработка ошибок
-        return api
-            .routerRequest(path, params)
-            .mergeMap(data => {
-                return Observable.empty<never>()
-            })
-            .catch(error => {
-                console.error(error)
-                return Observable.empty()
-            })
-    })
 
 export const routerEpics = {
     changeLocation,

--- a/src/epics/router/__tests__/handleRouter.test.ts
+++ b/src/epics/router/__tests__/handleRouter.test.ts
@@ -1,0 +1,64 @@
+/*
+ * TESLER-UI
+ * Copyright (C) 2018-2021 Tesler Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { testEpic } from '../../../tests/testEpic'
+import { $do } from '../../../actions/actions'
+import { ActionsObservable } from 'redux-observable'
+import { mockStore } from '../../../tests/mockStore'
+import { Store } from 'redux'
+import { Store as CoreStore } from '../../../interfaces/store'
+import { handleRouter } from '../handleRouter'
+import { Observable } from 'rxjs'
+import * as api from '../../../api/api'
+
+const errorMock = jest.fn()
+const routerMock = jest.fn().mockImplementation((path, params) => {
+    if (path === '/error') {
+        return Observable.throw('404 NOT FOUND')
+    }
+    return Observable.of('200 OK')
+})
+
+jest.spyOn(console, 'error').mockImplementation(errorMock)
+jest.spyOn(api, 'routerRequest').mockImplementation(routerMock)
+
+describe('selectScreenFail', () => {
+    let store: Store<CoreStore> = null
+
+    beforeAll(() => {
+        store = mockStore()
+    })
+
+    it('Sends a requst to Tesler API router endpoint', () => {
+        const action = $do.handleRouter({ path: '/data', params: { someParam: 3 } })
+        const epic = handleRouter(ActionsObservable.of(action), store)
+        testEpic(epic, res => {
+            expect(res.length).toBe(0)
+            expect(routerMock).toBeCalledWith('/data', expect.objectContaining({ someParam: 3 }))
+        })
+    })
+
+    it('Writes a console error if request fails.', () => {
+        const action = $do.handleRouter({ path: '/error', params: { someParam: 3 } })
+        const epic = handleRouter(ActionsObservable.of(action), store)
+        testEpic(epic, res => {
+            expect(res.length).toBe(0)
+            expect(routerMock).toBeCalledWith('/error', expect.objectContaining({ someParam: 3 }))
+            expect(errorMock).toBeCalledWith('404 NOT FOUND')
+        })
+    })
+})

--- a/src/epics/router/handleRouter.ts
+++ b/src/epics/router/handleRouter.ts
@@ -1,0 +1,52 @@
+/*
+ * TESLER-UI
+ * Copyright (C) 2018-2021 Tesler Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Observable } from 'rxjs'
+import { Store } from 'redux'
+import { Epic, types, ActionsMap } from '../../actions/actions'
+import { Store as CoreStore } from '../../interfaces/store'
+import { routerRequest } from '../../api/api'
+
+export const handleRouter: Epic = (action$, store) =>
+    action$.ofType(types.handleRouter).switchMap(action => {
+        return handleRouterImpl(action, store)
+    })
+
+/**
+ * Default implementation for `handleRouter` epic.
+ *
+ * If server routing is used, this epic will send a requst to Tesler API router endpoint.
+ * It writes a console error if request fails.
+ *
+ * @param action This epic will fire on {@link ActionPayloadTypes.handleRouter | handleRouter} action
+ * @param store Redux store instance
+ * @returns Default implementation does not throw any additional actions
+ * @category Epics
+ */
+export function handleRouterImpl(action: ActionsMap['handleRouter'], store: Store<CoreStore>): Observable<never> {
+    const path = action.payload.path
+    const params = action.payload.params
+    // todo: Handle errors
+    return routerRequest(path, params)
+        .mergeMap(data => {
+            return Observable.empty<never>()
+        })
+        .catch(error => {
+            console.error(error)
+            return Observable.empty()
+        })
+}

--- a/src/epics/view/fileUploadConfirm.ts
+++ b/src/epics/view/fileUploadConfirm.ts
@@ -41,7 +41,7 @@ export const fileUploadConfirm: Epic = (action$, store) =>
     })
 
 /**
- * Default implementation for `fileUploadConfirmImpl` epic
+ * Default implementation for `fileUploadConfirm` epic
  *
  * It sends customAction request for `file-upload-save` endpoint with `bulkIds` data
  * containing ids of uploaded files.

--- a/src/index.ts
+++ b/src/index.ts
@@ -221,7 +221,8 @@ export { selectViewImpl } from './epics/data/selectView'
 export { drillDownImpl } from './epics/router/drilldown'
 export { selectScreenImpl } from './epics/router/selectScreen'
 export { selectViewFailImpl } from './epics/router/selectViewFail'
-export { loginDone } from './epics/router/loginDone'
+export { loginDoneImpl } from './epics/router/loginDone'
+export { handleRouterImpl } from './epics/router/handleRouter'
 
 /**
  * Autosave middleware utils

--- a/yarn.lock
+++ b/yarn.lock
@@ -7972,7 +7972,7 @@ typedoc-default-themes@0.12.1:
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.12.1.tgz#6c4a759f9dc365b4021579587b3773deb6fb6eeb"
   integrity sha512-6PEvV+/kWAJeUwEtrKgIsZQSbybW5DGCr6s2mMjHsDplpgN8iBHI52UbA+2C+c2TMCxBNMK9TMS6pdeIdwsLSw==
 
-typedoc@^0.20.14:
+typedoc@0.20.14:
   version "0.20.14"
   resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.20.14.tgz#894ff71841a4abbe8f46cf52f3cc96c9d68328dc"
   integrity sha512-9bsZp5/qkl+gDSv9DRvHbfbY8Sr0tD8fKx7hNIvcluxeAFzBCEo9o0qDCdLUZw+/axbfd9TaqHvSuCVRu+YH6Q==


### PR DESCRIPTION
dAlso:
- strict typedoc version
- `fileUploadConfirmImpl` description referencing itself instead of `fileUploadConfirm`
- replace deprecated `ObjectMap` with `Record` for `GetParamsMap` type