### PR TITLE
If record is present, cursor shouldn't be reset (#566)

### DIFF
--- a/src/reducers/screen.ts
+++ b/src/reducers/screen.ts
@@ -106,7 +106,7 @@ export function screen(state = initialState, action: AnyAction): ScreenState {
             )
                 .filter(bcName => state.bo.bc[bcName])
                 .forEach(bcName => {
-                    newBcs[bcName] = { ...state.bo.bc[bcName], page: 1, loading: true }
+                    newBcs[bcName] = { ...state.bo.bc[bcName], page: 1 }
                 })
             return {
                 ...state,
@@ -294,7 +294,7 @@ export function screen(state = initialState, action: AnyAction): ScreenState {
                 newCursors[bcName] = { ...state.bo.bc[bcName], cursor }
                 newCache[bcName] = cursor
             })
-            // Сбросить также курсоры у всех дочерних БК от запрошенных
+            // Also reset cursors of all children of requested BCs
             const changedParents = Object.values(newCursors).map(bc => `${bc.url}/:id`)
             Object.values(state.bo.bc).forEach(bc => {
                 if (changedParents.some(item => bc.url.includes(item))) {
@@ -367,7 +367,6 @@ export function screen(state = initialState, action: AnyAction): ScreenState {
                         ...state.bo.bc,
                         [action.payload.bcName]: {
                             ...prevBc,
-                            cursor: null,
                             loading: true
                         }
                     }


### PR DESCRIPTION
See #566 

### Addition
View selection shouldn't mark all its BCs as loading (see #530)
Otherwise we can reach next situation:
Let it be a view includes widget with BC `exampleBc` and type which is  included into `skipWidgetTypes`. If there is no one else widget with BC `exampleBc` then there is no data loading for `exampleBc` in fact. But action of view selecting has marked `exampleBc` as loading already. So if an application has only one such widget  then `exampleBc` become marked as loading permanently.