### PR TITLE
fix MultiField styles

### DIFF
--- a/src/components/ui/MultiField/MultiField.less
+++ b/src/components/ui/MultiField/MultiField.less
@@ -23,13 +23,6 @@
     margin-right: 8px;
 }
 
-.listMultiValue {
-    max-width: 150px;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    word-wrap: break-word
-}
-
 .listMultiValueText {
     color: #595959;
 }

--- a/src/components/ui/MultiField/MultiField.tsx
+++ b/src/components/ui/MultiField/MultiField.tsx
@@ -22,7 +22,7 @@ export interface MultiFieldProps {
 const MultiField: React.FunctionComponent<MultiFieldProps> = props => {
     const valuesStyle = props.style === 'list' ? styles.listValues : styles.inlineValues
     const valueStyle = props.style === 'list' ? styles.listValue : styles.inlineValue
-    const multiValueStyle = props.style === 'list' ? styles.listMultiValue : styles.inlineMultiValue
+    const multiValueStyle = props.style !== 'list' && styles.inlineMultiValue
     return (
         <div className={valuesStyle}>
             {props.fields.map(fieldMeta => {


### PR DESCRIPTION
Old styles caused error with colored fields, because text go beyond colored area.
Also it caused problems with long noncolored fields, because text didn't wrap.

Now colored fields don't have width restriction, and long text also wrap.