### PR TITLE
Remove backend-affecting types and reexport them from "@tesler-ui/schema"

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,14 @@
     "test:coverage": "jest --coverage --coverageProvider=v8",
     "lint": "yarn eslint ./src",
     "check": "yarn run lint && yarn run test",
-    "doc:gen": "typedoc --out docs --categorizeByGroup src/index.ts src/interfaces/index.ts --categorizeByGroup false --readme none"
+    "doc:gen": "typedoc --out docs --categorizeByGroup src/index.ts src/interfaces/index.ts --categorizeByGroup false --readme none",
+    "gen:schema": "node ./node_modules/@tesler-ui/schema/bin/build-schema"
   },
   "devDependencies": {
+    "@tesler-ui/schema": "^0.2.0",
     "@types/classnames": "2.2.6",
     "@types/diff": "4.0.2",
-    "@types/enzyme": "3.10.3",
+    "@types/enzyme": "3.10.7",
     "@types/enzyme-adapter-react-16": "1.0.5",
     "@types/history": "4.7.2",
     "@types/jest": "24.0.18",
@@ -99,5 +101,8 @@
     "redux": "^4.0.5",
     "redux-observable": "^0.14.1",
     "rxjs": "^5.5.12"
+  },
+  "browser": {
+    "@tesler-ui/schema": false
   }
 }

--- a/src/interfaces/data.ts
+++ b/src/interfaces/data.ts
@@ -1,5 +1,6 @@
 import { OperationPostInvokeAny, OperationPreInvoke } from './operation'
-import { DrillDownType } from './router'
+import { DataValue, DataItem } from '@tesler-ui/schema'
+export { DataValue, DataItem, MultivalueSingleValue, MultivalueSingleValueOptions, RecordSnapshotState } from '@tesler-ui/schema'
 
 /**
  * API's response on Business Component's data request
@@ -10,35 +11,11 @@ export interface BcDataResponse {
 }
 
 /**
- * Instance of `Business component` data
- * Has unlimited number of fields, which available to widget
- */
-export interface DataItem {
-    /**
-     * Record's identificator
-     */
-    id: string
-    /**
-     * Version of last record's edit
-     */
-    vstamp: number
-    /**
-     * User fields
-     */
-    [fieldName: string]: DataValue
-}
-
-/**
  * Edited changes
  */
 export interface PendingDataItem {
     [fieldName: string]: DataValue
 }
-
-/**
- * Possible types of fields values
- */
-export type DataValue = string | number | boolean | null | MultivalueSingleValue[] | undefined | DataItem[]
 
 /**
  * State of `data` in global store
@@ -71,44 +48,6 @@ export interface DataItemResponse {
          */
         preInvoke?: OperationPreInvoke
     }
-}
-
-export const enum RecordSnapshotState {
-    noChange = 'noChange',
-    new = 'new',
-    deleted = 'deleted'
-}
-
-/**
- * Structure which contain `Multivalue` field's values
- */
-export interface MultivalueSingleValue {
-    /**
-     * Record's identificator
-     */
-    id: string
-    /**
-     * Showed value
-     */
-    value: string
-    options?: MultivalueSingleValueOptions
-}
-
-/**
- * `Multivalue` field's options
- */
-export interface MultivalueSingleValueOptions {
-    /**
-     * Hint for value
-     */
-    hint?: string
-    /**
-     * Type of Icon
-     */
-    icon?: string
-    drillDown?: string
-    drillDownType?: DrillDownType
-    snapshotState?: RecordSnapshotState
 }
 
 /**

--- a/src/interfaces/navigation.ts
+++ b/src/interfaces/navigation.ts
@@ -1,16 +1,5 @@
-/**
- * Description of the destination in the navigation menu.
- *
- * @param viewName Identifier of view.
- */
-export interface ViewNavigationItem {
-    // TODO: Should not be optional in 2.0.0
-    viewName?: string
-    hidden?: boolean
-    /** TODO: remove in 2.0.0 */
-    id?: string
-}
-
+import { ViewNavigationGroup, MenuItem, ViewNavigationCategory, ViewNavigationItem } from '@tesler-ui/schema'
+export { ViewNavigationGroup, MenuItem, ViewNavigationCategory, ViewNavigationItem } from '@tesler-ui/schema'
 /**
  * Returns MenuItem if it is ViewNavigationItem
  *
@@ -19,20 +8,6 @@ export interface ViewNavigationItem {
  */
 export function isViewNavigationItem(item: MenuItem): item is ViewNavigationItem {
     return !!item && 'viewName' in item
-}
-
-/**
- * Description of the category in the navigation menu.
- * Used to create nesting levels of menu items.
- *
- * @param categoryName The name of the category.
- * @param child list of categories or menu items included in a category.
- * @deprecated ViewNavigationCategory will be deleted in 2.0.0
- * @category Type Guards
- */
-export interface ViewNavigationCategory {
-    categoryName: string
-    child: Array<ViewNavigationCategory | ViewNavigationItem>
 }
 
 /**
@@ -45,23 +20,6 @@ export function isViewNavigationCategory(item: any): item is ViewNavigationCateg
 }
 
 /**
- * Description of groups in the navigation menu.
- *
- * Used to create nesting levels of menu items.
- *
- * @param title Title of group. Navigation element shows it to user.
- * @param child Array of navigation elements specified below group(View or inner Group)
- */
-export interface ViewNavigationGroup {
-    /** TODO identifier will be nullable and string-only in 2.0.0 */
-    id?: string | number
-    title: string
-    child: Array<ViewNavigationGroup | ViewNavigationItem>
-    hidden?: boolean
-    defaultView?: string
-}
-
-/**
  * Returns MenuItem if it is ViewNavigationGroup
  *
  * @param item to be identified as group
@@ -71,11 +29,6 @@ export function isViewNavigationGroup(item: MenuItem): item is ViewNavigationGro
     // TODO: remove 'categoryName' check in 2.0.0
     return !!item && 'child' in item && !('categoryName' in item)
 }
-
-/**
- * The type of object to describe the menu items in the navigation.
- */
-export type MenuItem = ViewNavigationGroup | ViewNavigationCategory | ViewNavigationItem
 
 /**
  * 1 - for static, top level navigation

--- a/src/interfaces/operation.ts
+++ b/src/interfaces/operation.ts
@@ -1,18 +1,8 @@
 import { DrillDownType } from './router'
 import { AppNotificationType } from './objectMap'
 import { DataItem } from './data'
-
-/**
- * TODO: Rename to CoreOperationRole in 2.0.0
- */
-export const enum OperationTypeCrud {
-    create = 'create',
-    save = 'save',
-    delete = 'delete',
-    associate = 'associate',
-    cancelCreate = 'cancel-create',
-    fileUpload = 'file-upload'
-}
+import { OperationTypeCrud, OperationType } from '@tesler-ui/schema'
+export { OperationTypeCrud, OperationType, OperationInclusionDescriptor } from '@tesler-ui/schema'
 
 export const coreOperations = [
     OperationTypeCrud.create,
@@ -25,24 +15,11 @@ export const coreOperations = [
 
 /**
  *
- * @param operationType
- */
-export function isCoreOperation(operationType: string): operationType is OperationTypeCrud {
-    return coreOperations.includes(operationType as OperationTypeCrud)
-}
-
-/**
- *
  * @param operation
  */
 export function isOperationGroup(operation: Operation | OperationGroup): operation is OperationGroup {
     return Array.isArray((operation as OperationGroup).actions)
 }
-
-/**
- * String that uniquely identifies an operation on widget
- */
-export type OperationType = OperationTypeCrud | string
 
 /**
  * User operation: CRUD or any custom business action.
@@ -373,28 +350,6 @@ export type OperationScope = 'bc' | 'record' | 'page' | 'associate'
 export interface AssociatedItem extends DataItem {
     _associate: boolean
 }
-
-/**
- * Descriptor enabling operation on widget:
- * - string (if you just need to include / exclude operation or groups)
- * - object, if this is group in which you want to selectively include or exclude the operation
- */
-export type OperationInclusionDescriptor =
-    | string
-    | {
-          /**
-           * Type of transaction; a string that uniquely identifies the operation on the widget
-           */
-          type: OperationType
-          /**
-           * List of included operations or groups operations
-           */
-          include?: OperationInclusionDescriptor[]
-          /**
-           * List of excluded operations or groups operations
-           */
-          exclude?: OperationType[]
-      }
 
 export interface OperationError {
     success: false

--- a/src/interfaces/router.ts
+++ b/src/interfaces/router.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export { DrillDownType } from '@tesler-ui/schema'
 
 export interface Route {
     type: RouteType
@@ -30,30 +31,4 @@ export const enum RouteType {
     router = 'router',
     invalid = 'invalid',
     unknown = 'unknown'
-}
-
-/**
- * Types of drilldowns in the application, specified by Tesler API
- */
-export const enum DrillDownType {
-    /**
-     * Drilldown to inner entity of the application (screen, view), i.e. url will be places after route hash sy: `#/${inner}`
-     */
-    inner = 'inner',
-    /**
-     * Drilldown to an url relative to the current url: `/${relative}`
-     */
-    relative = 'relative',
-    /**
-     * Drilldown to an url relative to the current url: `/${relative}` that opens in a new browser tab
-     */
-    relativeNew = 'relativeNew',
-    /**
-     * An external redirect, i.e. `http://${external}`
-     */
-    external = 'external',
-    /**
-     * An external redirect, i.e. `http://${external}` that opens in a new browser tab
-     */
-    externalNew = 'externalNew'
 }

--- a/src/interfaces/view.ts
+++ b/src/interfaces/view.ts
@@ -4,6 +4,7 @@ import { PendingDataItem, PickMap } from '../interfaces/data'
 import { SystemNotification } from './objectMap'
 import { OperationTypeCrud, OperationPostInvokeConfirm } from './operation'
 import { AxiosError } from 'axios'
+export { FieldType } from '@tesler-ui/schema'
 
 export interface ViewSelectedCell {
     widgetName: string
@@ -178,43 +179,6 @@ export interface PopupData {
      * TODO: Used only by assocs so probably move to AssocPopupDescriptor
      */
     isFilter?: boolean
-}
-
-export const enum FieldType {
-    number = 'number',
-    input = 'input',
-    monthYear = 'monthYear',
-    date = 'date',
-    dateTime = 'dateTime',
-    dateTimeWithSeconds = 'dateTimeWithSeconds',
-    checkbox = 'checkbox',
-    /**
-     * @deprecated TODO: project-specific, remove in 2.0.0
-     */
-    checkboxSql = 'checkboxSql',
-    /**
-     * @deprecated TODO: project-specific, remove in 2.0.0
-     */
-    DMN = 'DMN',
-    pickList = 'pickList',
-    inlinePickList = 'inline-pickList',
-    dictionary = 'dictionary',
-    hidden = 'hidden', // @deprecated TODO: Remove in 2.0.0 in favor of `hidden` flag of widget meta field description
-    text = 'text',
-    percent = 'percent',
-    fileUpload = 'fileUpload',
-    money = 'money',
-    /**
-     * @deprecated TODO: project-specific, remove in 2.0.0
-     */
-    comboCondition = 'combo-condition',
-    richText = 'richText',
-    printForm = 'printForm',
-    multifield = 'multifield',
-    multivalue = 'multivalue',
-    multivalueHover = 'multivalueHover',
-    hint = 'hint',
-    radio = 'radio'
 }
 
 export type ApplicationError = BusinessError | SystemError | ApplicationErrorBase

--- a/src/interfaces/widget.ts
+++ b/src/interfaces/widget.ts
@@ -1,27 +1,40 @@
-import { FieldType } from './view'
+import { WidgetShowCondition, WidgetTypes, WidgetOptions, WidgetFormField, WidgetListField, WidgetInfoField } from '@tesler-ui/schema'
 import { ConnectedComponent } from 'react-redux'
 import { FunctionComponent } from 'react'
-import { PickMap, DataValue } from './data'
-import { OperationType, OperationInclusionDescriptor } from './operation'
-
-export const enum WidgetTypes {
-    Info = 'Info',
-    Form = 'Form',
-    List = 'List',
-    DataGrid = 'DataGrid',
-    AssocListPopup = 'AssocListPopup',
-    PickListPopup = 'PickListPopup',
-    HeaderWidget = 'HeaderWidget',
-    SecondLevelMenu = 'SecondLevelMenu',
-    ThirdLevelMenu = 'ThirdLevelMenu',
-    FourthLevelMenu = 'FourthLevelMenu',
-    WidgetCreator = 'WidgetCreator',
-    Pivot = 'Pivot',
-    DimFilter = 'DimFilter',
-    Text = 'Text',
-    FlatTree = 'FlatTree',
-    FlatTreePopup = 'FlatTreePopup'
-}
+export {
+    WidgetShowCondition,
+    WidgetTypes,
+    WidgetOptions,
+    LayoutRow,
+    LayoutCol,
+    WidgetOperations,
+    TableOperations,
+    PositionTypes,
+    WidgetTableHierarchy,
+    WidgetFieldBase,
+    WidgetListFieldBase,
+    WidgetFormFieldBase,
+    AllWidgetTypeFieldBase,
+    NumberFieldMeta,
+    DateFieldMeta,
+    CheckboxFieldMeta,
+    DateTimeFieldMeta,
+    DateTimeWithSecondsFieldMeta,
+    DictionaryFieldMeta,
+    TextFieldMeta,
+    InputFieldMeta,
+    MultiFieldMeta,
+    MultivalueFieldMeta,
+    PickListFieldMeta,
+    InlinePickListFieldMeta,
+    FileUploadFieldMeta,
+    WidgetFormField,
+    WidgetListField,
+    HiddenFieldMeta,
+    RadioButtonFieldMeta,
+    WidgetField,
+    WidgetInfoField
+} from '@tesler-ui/schema'
 
 /**
  * Different widget types that are considered `tables` in nature for purposes of applying some shared features.
@@ -52,220 +65,9 @@ export const PopupWidgetTypes = [WidgetTypes.PickListPopup, WidgetTypes.AssocLis
  */
 type TableLikeWidgetType = typeof TableLikeWidgetTypes[number]
 
-export interface WidgetFieldBase {
-    type: FieldType
-    key: string
-    drillDown?: boolean
-    bgColor?: string
-    bgColorKey?: string
-    label?: string
-    snapshotKey?: string
-    /**
-     * Maximum number of characters
-     */
-    maxInput?: number
-    /**
-     * Whether the field is hidden
-     */
-    hidden?: boolean
-    /**
-     * Shift value of different hierarchy level
-     */
-    hierarchyShift?: boolean
-    drillDownKey?: string
-}
-
-export interface WidgetListFieldBase extends WidgetFieldBase {
-    title: string
-    width?: number
-}
-
-export interface WidgetFormFieldBase extends WidgetFieldBase {
-    label: string
-}
-
-export type AllWidgetTypeFieldBase = WidgetFormFieldBase | WidgetListFieldBase
-
-export type NumberFieldMeta = AllWidgetTypeFieldBase & {
-    type: FieldType.number | FieldType.money | FieldType.percent
-    digits?: number
-    nullable?: boolean
-}
-
-export type DateFieldMeta = AllWidgetTypeFieldBase & {
-    type: FieldType.date
-}
-
-export type CheckboxFieldMeta = AllWidgetTypeFieldBase & {
-    type: FieldType.checkbox
-}
-
-export type DateTimeFieldMeta = AllWidgetTypeFieldBase & {
-    type: FieldType.dateTime
-}
-
-export type DateTimeWithSecondsFieldMeta = AllWidgetTypeFieldBase & {
-    type: FieldType.dateTimeWithSeconds
-}
-
-export type DictionaryFieldMeta = AllWidgetTypeFieldBase & {
-    type: FieldType.dictionary
-    multiple?: boolean
-    dictionaryName?: string
-}
-
-export type TextFieldMeta = AllWidgetTypeFieldBase & {
-    type: FieldType.text
-    popover?: boolean
-}
-
-export type InputFieldMeta = AllWidgetTypeFieldBase & {
-    type: FieldType.input | FieldType.hint
-}
-
-export type MultiFieldMeta = AllWidgetTypeFieldBase & {
-    type: FieldType.multifield
-    fields: WidgetField[]
-    style: 'inline' | 'list'
-}
-
-export type MultivalueFieldMeta = AllWidgetTypeFieldBase & {
-    type: FieldType.multivalue | FieldType.multivalueHover
-    popupBcName?: string
-    assocValueKey?: string
-    associateFieldKey?: string
-    displayedKey?: string
-}
-
-export type PickListFieldMeta = AllWidgetTypeFieldBase & {
-    type: FieldType.pickList
-    popupBcName: string
-    pickMap: PickMap
-}
-
-export type InlinePickListFieldMeta = AllWidgetTypeFieldBase & {
-    type: FieldType.inlinePickList
-    searchSpec: string
-    popupBcName: string
-    pickMap: PickMap
-}
-
-export type FileUploadFieldMeta = AllWidgetTypeFieldBase & {
-    type: FieldType.fileUpload
-    fileIdKey: string
-    fileSource: string
-    snapshotFileIdKey?: string
-}
-
-/**
- * @deprecated TODO: Remove in 2.0.0 in favor of `hidden` flag of widget meta field description
- */
-export type HiddenFieldMeta = AllWidgetTypeFieldBase & {
-    type: FieldType.hidden
-}
-
-export type RadioButtonFieldMeta = AllWidgetTypeFieldBase & {
-    type: FieldType.radio
-}
-
-/**
- * Field descriptor in widget configuration
- */
-export type WidgetField =
-    | NumberFieldMeta
-    | DateFieldMeta
-    | DateTimeFieldMeta
-    | DateTimeWithSecondsFieldMeta
-    | DictionaryFieldMeta
-    | TextFieldMeta
-    | MultiFieldMeta
-    | InputFieldMeta
-    | MultivalueFieldMeta
-    | PickListFieldMeta
-    | InlinePickListFieldMeta
-    | FileUploadFieldMeta
-    | CheckboxFieldMeta
-    | HiddenFieldMeta
-    | RadioButtonFieldMeta
-
-export type WidgetFormField = Extract<WidgetField, WidgetFormFieldBase>
-
-export type WidgetListField = Extract<WidgetField, WidgetListFieldBase>
-
-/**
- *
- */
-export type WidgetInfoField = WidgetFormField & {
-    drillDownTitle?: string
-    drillDownTitleKey?: string
-    hintKey?: string
-}
-
 export interface WidgetInfoOptions {
     fieldBorderBottom?: boolean
     footer?: string
-}
-
-/**
- * @param readOnly All widget fields are not editable
- * @param tableOperations Options for allowed on table widget actions
- */
-export interface WidgetOptions {
-    layout?: {
-        header?: string[]
-        aside?: string[]
-        rows: LayoutRow[]
-    }
-    /**
-     * Options for allowed on table widget actions
-     */
-    tableOperations?: TableOperations
-    /**
-     * TODO: Move all hierarchy-specific properties to a single property
-     */
-    hierarchy?: WidgetTableHierarchy[]
-    hierarchySameBc?: boolean
-    hierarchyFull?: boolean
-    hierarchyParentKey?: string
-    hierarchyGroupSelection?: boolean
-    hierarchyGroupDeselection?: boolean
-    hierarchyTraverse?: boolean
-    hierarchyRadio?: boolean
-    hierarchyRadioAll?: boolean
-    hierarchyDisableRoot?: boolean
-    /**
-     * Disable searched item descendants in fullHierarchy search
-     */
-    hierarchyDisableDescendants?: boolean
-    hierarchyDisableParent?: boolean
-    actionGroups?: WidgetOperations
-    /**
-     * All widget fields are not editable
-     */
-    readOnly?: boolean
-    /**
-     * @deprecated TODO: Remove in 2.0.0 in favor of actionGroups
-     */
-    hideActionGroups?: string[]
-    /**
-     * Record field which value will be used as a title for the whole record
-     * for this particular widget
-     */
-    displayedValueKey?: string
-    /**
-     * Disable tooltip with error text
-     */
-    disableHoverError?: boolean
-    /**
-     * Disable notification after failed operation
-     */
-    disableNotification?: boolean
-    /**
-     * Allow selecting multiple items for FlatListPopup
-     *
-     * TODO: Move to separate interface
-     */
-    multiple?: boolean
 }
 
 export interface WidgetMeta {
@@ -280,25 +82,6 @@ export interface WidgetMeta {
     options?: WidgetOptions
     showCondition?: WidgetShowCondition
     description?: string // description for documentation
-}
-
-/**
- * Show widget only if certain condition is met
- *
- * Supported conditions:
- * - Active record for specified business component {bcName} should contain field {fieldKey}
- * with value {fieldValue}
- *
- * @param bcName Business component where field condition is checked
- * @param fieldCondition Field key and value expected from this field
- */
-export interface WidgetShowCondition {
-    bcName: string
-    isDefault: boolean
-    params: {
-        fieldKey: string
-        value: DataValue
-    }
 }
 
 /**
@@ -399,82 +182,6 @@ export interface WidgetTextMeta extends WidgetMeta {
  * A widget configuration of any known type
  */
 export type WidgetMetaAny = WidgetFormMeta | WidgetTableMeta | WidgetTextMeta | WidgetInfoMeta
-
-/**
- * Description of possible positioning options
- */
-export const enum PositionTypes {
-    Top = 'Top',
-    Bottom = 'Bottom',
-    TopAndBottom = 'TopAndBottom'
-}
-
-/**
- * Description of options of allowed on table widget actions
- */
-export interface TableOperations {
-    /**
-     * Describes position of tableOperations relatively of table
-     */
-    position?: PositionTypes
-}
-
-/**
- * Configuration descriptor for hierarchy subset of table widgets.
- *
- * Each descriptor describes a specific level of hierarchy
- */
-export interface WidgetTableHierarchy {
-    /**
-     * Which business component is displayed on this level
-     */
-    bcName: string
-    /**
-     * What record field to use as displayed value of that record
-     */
-    assocValueKey?: string
-    /**
-     * If true only one item can be selected
-     */
-    radio?: boolean
-    /**
-     * Fields that will be displayed on this hierarchy level
-     */
-    fields: WidgetListField[]
-}
-
-/**
- * Operations description in `options` of widget meta, which allows its availability.
- */
-export interface WidgetOperations {
-    /**
-     * List of included operations or groups of operations
-     */
-    include?: OperationInclusionDescriptor[]
-    /**
-     * List of excluded operations or groups of operations
-     */
-    exclude?: OperationType[]
-    /**
-     * default no crud save action
-     */
-    defaultSave?: string
-}
-
-/**
- * Description of the interface for WidgetOptions's layout.rows
- */
-export interface LayoutCol {
-    fieldKey: string
-    span?: number
-}
-
-/**
- * Description of the interface for LayoutRow
- */
-export interface LayoutRow {
-    cols: LayoutCol[]
-}
 
 export type CustomWidget = ConnectedComponent<any, any> | FunctionComponent<any>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -396,6 +396,15 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@tesler-ui/schema@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@tesler-ui/schema/-/schema-0.2.0.tgz#b26a7460e630b278872335bb86784d660468bac8"
+  integrity sha512-xHsCNGZ7CMaWgyMeDnZWv+VFdS98qFFt9nVJiXZ4z9KAYvAIKS53iWdXrtSpikB27ZanS4AeMRF88xkjBJw7Mg==
+  dependencies:
+    json-stable-stringify "^1.0.1"
+    path "^0.12.7"
+    typescript-json-schema "^0.48.0"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
@@ -471,10 +480,10 @@
     "@types/cheerio" "*"
     "@types/react" "*"
 
-"@types/enzyme@3.10.3":
-  version "3.10.3"
-  resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.10.3.tgz#02b6c5ac7d0472005944a652e79045e2f6c66804"
-  integrity sha512-f/Kcb84sZOSZiBPCkr4He9/cpuSLcKRyQaEE20Q30Prx0Dn6wcyMAWI0yofL6yvd9Ht9G7EVkQeRqK0n5w8ILw==
+"@types/enzyme@3.10.7":
+  version "3.10.7"
+  resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.10.7.tgz#ebdf3b972d293095e09af479e36c772025285e3a"
+  integrity sha512-J+0wduPGAkzOvW7sr6hshGv1gBI3WXLRTczkRKzVPxLP3xAkYxZmvvagSBPw8Z452fZ8TGUxCmAXcb44yLQksw==
   dependencies:
     "@types/cheerio" "*"
     "@types/react" "*"
@@ -550,6 +559,11 @@
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
+
+"@types/json-schema@^7.0.6":
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
+  integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
 "@types/json5@^0.0.29":
   version "0.0.29"
@@ -1129,6 +1143,11 @@ aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -1859,6 +1878,15 @@ cliui@^5.0.0:
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
 
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
 clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
@@ -2108,6 +2136,11 @@ create-react-class@^15.5.3:
   dependencies:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -2372,7 +2405,7 @@ diff-sequences@^26.6.2:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
 
-diff@4.0.2:
+diff@4.0.2, diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
@@ -2556,6 +2589,11 @@ emoji-regex@^7.0.1:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
@@ -2731,6 +2769,11 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+escalade@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -3348,7 +3391,7 @@ get-caller-file@^1.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -4018,6 +4061,11 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
+
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-generator-fn@^2.0.0:
   version "2.1.0"
@@ -4689,6 +4737,13 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
+json-stable-stringify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
+  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
+  dependencies:
+    jsonify "~0.0.0"
+
 json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -4728,6 +4783,11 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+jsonify@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
+  integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -5003,7 +5063,7 @@ make-dir@^2.0.0, make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -5806,6 +5866,14 @@ path-type@^3.0.0:
   dependencies:
     pify "^3.0.0"
 
+path@^0.12.7:
+  version "0.12.7"
+  resolved "https://registry.yarnpkg.com/path/-/path-0.12.7.tgz#d4dc2a506c4ce2197eb481ebfcd5b36c0140b10f"
+  integrity sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=
+  dependencies:
+    process "^0.11.1"
+    util "^0.10.3"
+
 pbkdf2@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.1.tgz#cb8724b0fada984596856d1a6ebafd3584654b94"
@@ -5993,7 +6061,7 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-process@^0.11.10:
+process@^0.11.1, process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
@@ -7328,7 +7396,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.6, source-map-support@~0.5.12:
+source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -7509,6 +7577,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^4.1.0, string-width@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
+  integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.0"
 
 string.prototype.matchall@^4.0.2:
   version "4.0.2"
@@ -7876,6 +7953,18 @@ ts-loader@6.2.2:
     micromatch "^4.0.0"
     semver "^6.0.0"
 
+ts-node@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
+  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+  dependencies:
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
+
 tsconfig-paths@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
@@ -7988,6 +8077,23 @@ typedoc@0.20.14:
     shelljs "^0.8.4"
     shiki "^0.2.7"
     typedoc-default-themes "0.12.1"
+
+typescript-json-schema@^0.48.0:
+  version "0.48.0"
+  resolved "https://registry.yarnpkg.com/typescript-json-schema/-/typescript-json-schema-0.48.0.tgz#d30e287319a09617e87d10c17f484077412a55e7"
+  integrity sha512-RDs66ANmjiqcSQ7dAeFIarF0ON6b+dxb5Fl1x53PK0p/QcqEoSN3kHsJTB0lgw+zWz6wdObCzk3jIwik3maK1Q==
+  dependencies:
+    "@types/json-schema" "^7.0.6"
+    glob "^7.1.6"
+    json-stable-stringify "^1.0.1"
+    ts-node "^9.1.1"
+    typescript "^4.1.3"
+    yargs "^16.2.0"
+
+typescript@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 typescript@~3.9.7:
   version "3.9.7"
@@ -8115,6 +8221,13 @@ util@0.10.3:
   integrity sha1-evsa/lCAUkZInj23/g7TeTNqwPk=
   dependencies:
     inherits "2.0.1"
+
+util@^0.10.3:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
+  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
+  dependencies:
+    inherits "2.0.3"
 
 util@^0.11.0:
   version "0.11.1"
@@ -8376,6 +8489,15 @@ wrap-ansi@^5.1.0:
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -8424,6 +8546,11 @@ y18n@^3.2.1:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
+y18n@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
+  integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
+
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
@@ -8456,6 +8583,11 @@ yargs-parser@^13.1.2:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-parser@^20.2.2:
+  version "20.2.4"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
+  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
 yargs-parser@^7.0.0:
   version "7.0.0"
@@ -8498,6 +8630,19 @@ yargs@^13.3.0:
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
 
+yargs@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
+
 yargs@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
@@ -8516,3 +8661,8 @@ yargs@^8.0.2:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^7.0.0"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
There are a lot of types that declared in Tesler UI while in fact those types describe both frontend entities and parts of screen/view/widget/sqlbc JSON descriptions which are stored in backend side of the application, which leads us to:
1) To generate JSON schemas we'll have to keep a separate instance of all the types in [@tesler-ui/schema](https://github.com/tesler-platform/tesler-schema), which is a double work and will definetly end up out of sync with each outher
2) This types being declared in Tesler UI are encouraging developers to modify the public contract which is in fact also affects how [Tesler API](https://github.com/tesler-platform/tesler) processes JSON descriptors for application entities.

Extracting them into separate repository will allow us to have a single source of truth about types affecting both frontend and JSON descriptors for application entities.

This PR adds `@tesler-ui/schema` and reexport those types from there so that client application could continue to referencing those types from Tesler UI.
