### PR TITLE
provide original store slice state before in went through Tesler reducer as a reducer argument to allow overriding built-in behavior

### DIFF
--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -1,24 +1,17 @@
 import React from 'react'
-import { Action, applyMiddleware, compose, createStore, Middleware, Store, StoreCreator } from 'redux'
+import { Action, Store } from 'redux'
 import { Provider as ReduxProvider } from 'react-redux'
-import { createEpicMiddleware, Epic, combineEpics as legacyCombineEpics } from 'redux-observable'
-import { reducers as coreReducers } from './reducers/index'
 import { Route } from './interfaces/router'
-import { ClientReducersMapObject, CombinedReducersMapObject, CoreReducer, Store as CoreStore } from './interfaces/store'
+import { ClientReducersMapObject, Store as CoreStore } from './interfaces/store'
 import { Location } from 'history'
-import { AnyAction } from './actions/actions'
 import { AxiosInstance } from 'axios'
 import { initHistory } from './reducers/router'
-import { combineReducers } from './utils/redux'
 import { initLocale } from './imports/i18n'
 import { Resource, i18n } from 'i18next'
-import CustomEpics, { isLegacyCustomEpics, AnyEpic } from './interfaces/customEpics'
-import combineEpics from './utils/combineEpics'
-import { legacyCoreEpics } from './epics'
-import { combineMiddlewares } from './utils/combineMiddlewares'
-import { middlewares as coreMiddlewares } from './middlewares'
+import CustomEpics, { AnyEpic } from './interfaces/customEpics'
 import { CustomMiddlewares } from './interfaces/customMiddlewares'
 import { defaultBuildLocation, defaultParseLocation } from './utils/history'
+import { configureStore } from './utils/configureStore'
 
 export interface ProviderProps<ClientState, ClientActions> {
     children: React.ReactNode
@@ -39,18 +32,9 @@ export interface ProviderProps<ClientState, ClientActions> {
  */
 export let store: Store<CoreStore> = null
 export let axiosInstance: AxiosInstance = null
-export let parseLocation: (loc: Location<any>) => Route = null
-export let buildLocation: (route: Route) => string = null
+export let parseLocation: (loc: Location<any>) => Route = defaultParseLocation
+export let buildLocation: (route: Route) => string = defaultBuildLocation
 export let localeProviderInstance: i18n = null
-
-/**
- * TODO
- *
- * @param storeCreator
- */
-function withLogger(storeCreator: StoreCreator): StoreCreator {
-    return (window as any).devToolsExtension ? (window as any).devToolsExtension()(storeCreator) : storeCreator
-}
 
 /**
  * TODO
@@ -92,56 +76,6 @@ export function getLocaleProviderInstance() {
 }
 
 /**
- * TODO
- *
- * @param customReducers
- * @param customEpics
- * @param useEpics
- * @param customMiddlewares
- */
-export function configureStore<ClientState, ClientActions extends Action<any>>(
-    customReducers = {} as ClientReducersMapObject<ClientState, ClientActions>,
-    customEpics: CustomEpics | Epic<any, ClientState> = null,
-    useEpics = true,
-    customMiddlewares: CustomMiddlewares = null
-): Store<ClientState & CoreStore> {
-    type CombinedActions = AnyAction & ClientActions
-    // If core reducer slices have a matching client app reducer slice
-    // launch the core first and then client
-    // TODO: Extract this to an utility
-    const reducers = { ...coreReducers } as CombinedReducersMapObject<CoreStore & ClientState, CombinedActions>
-    Object.keys(customReducers).forEach((reducerName: Extract<keyof ClientState, string>) => {
-        const coreInitialState = coreReducers[reducerName]?.(undefined, { type: ' UNKNOWN ACTION ' })
-        const reducerInitialState = {
-            ...(coreInitialState || ({} as ClientState)),
-            ...customReducers[reducerName].initialState
-        }
-
-        if (reducers[reducerName as keyof ClientState] && !customReducers[reducerName].override) {
-            const combined: CoreReducer<ClientState[keyof ClientState], CombinedActions> = (
-                state = reducerInitialState,
-                action,
-                getStore
-            ) => {
-                const storeAfterCore = coreReducers[reducerName](state, action, getStore)
-                return customReducers[reducerName as keyof ClientState].reducer(storeAfterCore, action, getStore)
-            }
-            reducers[reducerName as keyof ClientState] = combined
-        } else {
-            reducers[reducerName as keyof ClientState] = customReducers[reducerName].reducer
-        }
-    })
-
-    const middlewares: Middleware[] = combineMiddlewares(coreMiddlewares, customMiddlewares)
-
-    if (useEpics) {
-        const epics = isLegacyCustomEpics(customEpics) ? legacyCombineEpics(legacyCoreEpics, customEpics) : combineEpics(customEpics)
-        middlewares.push(createEpicMiddleware(epics))
-    }
-    return compose(applyMiddleware(...middlewares))(withLogger(createStore))(combineReducers(reducers))
-}
-
-/**
  *
  * @param props
  * @category Components
@@ -155,8 +89,12 @@ const Provider = <ClientState extends Partial<CoreStore>, ClientActions extends 
     if (props.axiosInstance) {
         axiosInstance = props.axiosInstance
     }
-    parseLocation = props.parseLocation || defaultParseLocation
-    buildLocation = props.buildLocation || defaultBuildLocation
+    if (props.parseLocation) {
+        parseLocation = props.parseLocation
+    }
+    if (props.buildLocation) {
+        buildLocation = props.buildLocation
+    }
     return <ReduxProvider store={store}>{props.children}</ReduxProvider>
 }
 

--- a/src/epics/router/__tests__/changeLocation.test.ts
+++ b/src/epics/router/__tests__/changeLocation.test.ts
@@ -139,7 +139,6 @@ describe('selectScreenFail', () => {
         store.getState().router.viewName = 'view-next'
         const epic = changeLocation(ActionsObservable.of(action), store)
         testEpic(epic, res => {
-            console.warn(res)
             expect(res.length).toBe(3)
             expect(res[0]).toEqual(
                 expect.objectContaining(

--- a/src/interfaces/store.ts
+++ b/src/interfaces/store.ts
@@ -12,18 +12,44 @@ export interface Store {
     view: ViewState
     data: DataState
     depthData: DepthDataState
-    [reducerName: string]: any // TODO: Исправить комбинирование редьюсеров и убрать
+    [reducerName: string]: any // TODO: Fix how reducers are combined and remove
 }
 
 export type CoreReducer<ReducerState, ClientActions, State = Store> = (
+    /**
+     * The state of Redux store slice
+     */
     state: ReducerState,
+    /**
+     * Redux action
+     */
     action: AnyAction & ClientActions,
-    store?: Readonly<State>
+    /**
+     * Allows direct access to other slices of redux store from the reducer
+     */
+    store?: Readonly<State>,
+    /**
+     * The original state of Redux store slice before in went through Tesler reducer;
+     *
+     * Can be used to implement your own logic in client application reducer for built-in action.
+     */
+    originalState?: ReducerState
 ) => ReducerState
 
 export interface ClientReducer<ReducerState, ClientActions> {
+    /**
+     * Initial state for Redux store slice; will replace built-in Tesler initial state for matching slice
+     */
     initialState: ReducerState
+    /**
+     * If true than custom reducer will replace built-in Tesler reducer for this store slice
+     *
+     * @deprecated TODO: This functionality is conceptionally flawed and will be removed in 2.0.0
+     */
     override?: boolean
+    /**
+     * Reducer function for specific store slice
+     */
     reducer: CoreReducer<ReducerState, ClientActions>
 }
 

--- a/src/reducers/router.ts
+++ b/src/reducers/router.ts
@@ -49,7 +49,7 @@ const initialState: Route = { type: RouteType.default, path: '/', params: null, 
 export function router(state: Route = initialState, action: AnyAction): Route {
     switch (action.type) {
         case types.loginDone:
-            return parseLocation(historyObj.location)
+            return parseLocation(historyObj?.location)
         case types.changeLocation:
             const rawLocation = action.payload.rawLocation
             if (rawLocation != null) {

--- a/src/utils/__tests__/configureStore.test.ts
+++ b/src/utils/__tests__/configureStore.test.ts
@@ -1,0 +1,88 @@
+import { $do, types } from '../../actions/actions'
+import { configureStore } from '../configureStore'
+import * as router from '../../Provider'
+
+jest.spyOn(router, 'parseLocation').mockImplementation(() => {
+    return { screenName: null, viewName: null, type: null, path: null, params: null }
+})
+
+describe('configureStore', () => {
+    it('handles built-in actions by built-in reducers', () => {
+        const store = configureStore({}, null, false, null)
+        expect(store.getState().session.active).toBe(false)
+        store.dispatch($do.loginDone({ screens: null }))
+        expect(store.getState().session.active).toBe(true)
+    })
+
+    it('applies custom reducer after Tesler built-in reducer', () => {
+        const mock = jest.fn()
+        const storeInstance = configureStore(
+            {
+                session: {
+                    initialState: {},
+                    reducer: (state, action, store, originalState) => {
+                        if (action.type === types.loginDone) {
+                            mock('success')
+                            return state
+                        }
+                        return state
+                    }
+                }
+            },
+            null,
+            false,
+            null
+        )
+        expect(storeInstance.getState().session.active).toBe(false)
+        storeInstance.dispatch($do.loginDone({ screens: null }))
+        expect(storeInstance.getState().session.active).toBe(true)
+        expect(mock).toBeCalledWith('success')
+    })
+
+    it('allows custom reducer to override built-in implementation ', () => {
+        const mock = jest.fn()
+        const storeInstance = configureStore(
+            {
+                session: {
+                    initialState: {},
+                    reducer: (state, action, store, originalState) => {
+                        if (action.type === types.loginDone) {
+                            mock('success')
+                            return originalState
+                        }
+                        return state
+                    }
+                }
+            },
+            null,
+            false,
+            null
+        )
+        expect(storeInstance.getState().session.active).toBe(false)
+        storeInstance.dispatch($do.loginDone({ screens: null }))
+        expect(storeInstance.getState().session.active).toBe(false)
+        expect(mock).toBeCalledWith('success')
+    })
+
+    it('allows reducers for custom store slice', () => {
+        const storeInstance = configureStore(
+            {
+                customSlice: {
+                    initialState: 0,
+                    reducer: (state = 0, action, store, originalState) => {
+                        if (action.type === types.loginDone) {
+                            return 1
+                        }
+                        return state
+                    }
+                }
+            },
+            null,
+            false,
+            null
+        )
+        expect(storeInstance.getState().customSlice).toBe(0)
+        storeInstance.dispatch($do.loginDone({ screens: null }))
+        expect(storeInstance.getState().customSlice).toBe(1)
+    })
+})

--- a/src/utils/configureStore.ts
+++ b/src/utils/configureStore.ts
@@ -1,0 +1,72 @@
+import { Action, applyMiddleware, compose, createStore, Middleware, Store, StoreCreator } from 'redux'
+import { createEpicMiddleware, Epic, combineEpics as legacyCombineEpics } from 'redux-observable'
+import { reducers as coreReducers } from '../reducers/index'
+import combineEpics from '../utils/combineEpics'
+import { legacyCoreEpics } from '../epics'
+import { combineMiddlewares } from '../utils/combineMiddlewares'
+import { middlewares as coreMiddlewares } from '../middlewares'
+import CustomEpics, { isLegacyCustomEpics } from '../interfaces/customEpics'
+import { combineReducers } from '../utils/redux'
+import { AnyAction } from '../actions/actions'
+import { ClientReducersMapObject, CombinedReducersMapObject, CoreReducer, Store as CoreStore } from '../interfaces/store'
+import { CustomMiddlewares } from '../interfaces/customMiddlewares'
+
+/**
+ * TODO
+ *
+ * @param storeCreator
+ */
+function withLogger(storeCreator: StoreCreator): StoreCreator {
+    return (window as any).devToolsExtension ? (window as any).devToolsExtension()(storeCreator) : storeCreator
+}
+
+/**
+ * Configures Redux store by apply redux-observable epic middleware and custom version of `combineReducers` function
+ *
+ * @param customReducers Client application reducers
+ * @param customEpics Client application epics
+ * @param useEpics Can be set to `false` if client application does not provide redux-observable peer dependency
+ * and does not rely on Tesler epics (e.g. importing only UI components)
+ * @param customMiddlewares Any additional middlewares provided by client application
+ */
+export function configureStore<ClientState, ClientActions extends Action<any>>(
+    customReducers = {} as ClientReducersMapObject<ClientState, ClientActions>,
+    customEpics: CustomEpics | Epic<any, ClientState> = null,
+    useEpics = true,
+    customMiddlewares: CustomMiddlewares = null
+): Store<ClientState & CoreStore> {
+    type CombinedActions = AnyAction & ClientActions
+    // If core reducer slices have a matching client app reducer slice
+    // launch the core first and then client
+    // TODO: Extract this to an utility
+    const reducers = { ...coreReducers } as CombinedReducersMapObject<CoreStore & ClientState, CombinedActions>
+    Object.keys(customReducers).forEach((reducerName: Extract<keyof ClientState, string>) => {
+        const coreInitialState = coreReducers[reducerName]?.(undefined, { type: ' UNKNOWN ACTION ' })
+        const reducerInitialState = {
+            ...(coreInitialState || ({} as ClientState)),
+            ...customReducers[reducerName].initialState
+        }
+
+        if (reducers[reducerName as keyof ClientState] && !customReducers[reducerName].override) {
+            const combined: CoreReducer<ClientState[keyof ClientState], CombinedActions> = (
+                state = reducerInitialState,
+                action,
+                getStore
+            ) => {
+                const storeAfterCore = coreReducers[reducerName](state, action, getStore)
+                return customReducers[reducerName as keyof ClientState].reducer(storeAfterCore, action, getStore, state)
+            }
+            reducers[reducerName as keyof ClientState] = combined
+        } else {
+            reducers[reducerName as keyof ClientState] = customReducers[reducerName].reducer
+        }
+    })
+
+    const middlewares: Middleware[] = combineMiddlewares(coreMiddlewares, customMiddlewares)
+
+    if (useEpics) {
+        const epics = isLegacyCustomEpics(customEpics) ? legacyCombineEpics(legacyCoreEpics, customEpics) : combineEpics(customEpics)
+        middlewares.push(createEpicMiddleware(epics))
+    }
+    return compose(applyMiddleware(...middlewares))(withLogger(createStore))(combineReducers(reducers))
+}


### PR DESCRIPTION
At the moment there is no obvious way to override Tesler reducer reacting to built-in action:

https://github.com/tesler-platform/tesler-ui/blob/668d0d2d69f15e256649aabbecd80c4563b0a29b/src/interfaces/store.ts#L24-L26

ClientReducer type provides `override` flag and it is in fact respected, but it is conceptionally flawed in a way that most projects treat slice reducer as a single function with a giant `switch` inside, so this flag will replace reducers for the entire store slice.
This has absolutely no usage in real life and will be removed 2.0.0

Two other currently available options:
1) Use custom action type - not always convinient as Tesler action might be dispatched deeply from Tesler epic or component so overriding reducer for one action will require a large chunk of code from client application developer; not vialable
2) Revert changes from Tesler reducer manually in client side reducer; this is how it's currently handled in most projects. Some disadvantages: developer has to look into Tesler implementation to understand what to revert; changes in Tesler reducer will break client reducer; addional code.

This PR provides client application reducer with additional argument: `originalState`, that contains the state of Redux store slice before it went through Tesler reducer:

```ts
export function session(
  state = initialState,
  action: AnyAction,
  store: Store,
  originalState: Session
): Session {
  switch (action.type) {
    case types.loginDone: {
      // implement custom logic and return based on `originalState` instead of `state`
      return { ...originalState }
    }
    // ...
  }
}
```