### PR TITLE
TableWidget filter for Checkbox field types

### DIFF
--- a/src/components/FilterPopup/FilterPopup.tsx
+++ b/src/components/FilterPopup/FilterPopup.tsx
@@ -70,7 +70,7 @@ export const FilterPopup: React.FC<FilterPopupProps> = props => {
             viewName,
             widgetName: widget.name
         }
-        if (!props.value) {
+        if (props.value === null || props.value === undefined) {
             dispatch($do.bcRemoveFilter({ bcName: widget.bcName, filter }))
         } else {
             dispatch($do.bcAddFilter({ bcName: widget.bcName, filter: newFilter }))

--- a/src/components/ui/FilterField/FilterField.test.tsx
+++ b/src/components/ui/FilterField/FilterField.test.tsx
@@ -64,7 +64,7 @@ describe('`<ColumnFilterControl />`', () => {
             />
         )
         expect(wrapper.find(Checkbox)).toHaveLength(1)
-        const e = { target: { value: true } } as any
+        const e = { target: { checked: true } } as any
         wrapper.find(Checkbox).invoke('onChange')(e)
         expect(onChange).toBeCalledWith(true)
     })

--- a/src/components/ui/FilterField/FilterField.tsx
+++ b/src/components/ui/FilterField/FilterField.tsx
@@ -59,7 +59,7 @@ export const ColumnFilterControl: React.FC<ColumnFilterControlProps> = props => 
             return (
                 <Checkbox
                     onChange={(e: CheckboxChangeEvent) => {
-                        props.onChange(e.target.value || null)
+                        props.onChange(e.target.checked)
                     }}
                 />
             )


### PR DESCRIPTION
See issue #593

Changes have been made to the filter processing for checkbox column type.

Checkbox filter control incorrectly uses the event field that changes the indicator checkbox.
`e.target.value` instead `e.target.checked` (FilterField.tsx)

Need change the filter handler behavior. Filter value `false` for it should be subject-specific, not just empty, which means clear filter.

Please check correctness of my solution, and let me know if the fix is accepted so that I can update `tesler-ui` version in my app.