### PR TITLE
deprecate `<SameBcHierarchyTable />` component, support column width for regular hierarchies with `hierarchySameBc` widget option; use strict versioning for `@tesler-ui/schema`

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "webpack-rxjs-externals": "1.1.0"
   },
   "dependencies": {
-    "@tesler-ui/schema": "^0.2.0",
+    "@tesler-ui/schema": "0.2.0",
     "classnames": "2.2.6",
     "core-js": "3.1.4",
     "diff": "4.0.2",

--- a/src/components/HierarchyTable/HierarchyTable.less
+++ b/src/components/HierarchyTable/HierarchyTable.less
@@ -43,3 +43,16 @@
 .selectColumn {
     text-align: center;
 }
+
+.sameHierarchyNode {
+    position: relative;
+}
+
+.expand {
+    font-size: 20px;
+    position: absolute;
+}
+
+.expandPadding {
+    margin-left: 40px;
+}

--- a/src/components/SameBcHierarchyTable/SameBcHierarchyTable.tsx
+++ b/src/components/SameBcHierarchyTable/SameBcHierarchyTable.tsx
@@ -61,6 +61,7 @@ const emptyData: AssociatedItem[] = []
 /**
  *
  * @param props
+ * @deprecated TODO: Will be removed in 2.0.0
  * @category Components
  */
 export const SameBcHierarchyTable: FunctionComponent<SameBcHierarchyTableProps> = props => {
@@ -239,7 +240,9 @@ function mapDispatchToProps(dispatch: Dispatch) {
 }
 
 const ConnectedHierarchyTable = connect(mapStateToProps, mapDispatchToProps)(SameBcHierarchyTable)
+
 /**
+ * @deprecated TODO: Will be removed in 2.0.0
  * @category Components
  */
 export default ConnectedHierarchyTable

--- a/src/components/widgets/AssocListPopup/AssocListPopup.tsx
+++ b/src/components/widgets/AssocListPopup/AssocListPopup.tsx
@@ -9,7 +9,6 @@ import { createMapDispatchToProps } from '../../../utils/redux'
 import HierarchyTable from '../../../components/HierarchyTable/HierarchyTable'
 import AssocTable from './AssocTable'
 import { Skeleton, Tag } from 'antd'
-import SameBcHierarchyTable from '../../SameBcHierarchyTable/SameBcHierarchyTable'
 import FullHierarchyTable from '../../FullHierarchyTable/FullHierarchyTable'
 import { AssociatedItem } from '../../../interfaces/operation'
 import { BcFilter, FilterType } from '../../../interfaces/filters'
@@ -203,11 +202,9 @@ export const AssocListPopup: FunctionComponent<IAssocListProps & IAssocListActio
     const title = props.components?.title === undefined ? defaultTitle : props.components.title
 
     const defaultTable =
-        props.widget.options?.hierarchy || props.widget.options?.hierarchySameBc || props.widget.options?.hierarchyFull ? (
+        props.widget.options?.hierarchy || props.widget.options?.hierarchyFull ? (
             props.widget.options.hierarchyFull ? (
                 <FullHierarchyTable meta={props.widget} assocValueKey={props.assocValueKey} selectable />
-            ) : props.widget.options.hierarchySameBc ? (
-                <SameBcHierarchyTable meta={props.widget} assocValueKey={props.assocValueKey} selectable />
             ) : (
                 <HierarchyTable meta={props.widget} assocValueKey={props.assocValueKey} selectable />
             )

--- a/src/components/widgets/PickListPopup/PickListPopup.tsx
+++ b/src/components/widgets/PickListPopup/PickListPopup.tsx
@@ -10,7 +10,6 @@ import { Table, Skeleton } from 'antd'
 import { ColumnProps } from 'antd/es/table'
 import { DataItem, PickMap } from '../../../interfaces/data'
 import { ChangeDataItemPayload } from '../../Field/Field'
-import SameBcHierarchyTable from '../../SameBcHierarchyTable/SameBcHierarchyTable'
 import HierarchyTable from '../../../components/HierarchyTable/HierarchyTable'
 import FullHierarchyTable from '../../FullHierarchyTable/FullHierarchyTable'
 import ColumnTitle from '../../ColumnTitle/ColumnTitle'
@@ -133,11 +132,9 @@ export const PickListPopup: FunctionComponent<PickListPopupProps & PickListPopup
     const footer = props.components?.footer === undefined ? defaultFooter : props.components.footer
 
     const defaultTable =
-        props.widget.options?.hierarchy || props.widget.options?.hierarchySameBc || props.widget.options?.hierarchyFull ? (
+        props.widget.options?.hierarchy || props.widget.options?.hierarchyFull ? (
             props.widget.options.hierarchyFull ? (
                 <FullHierarchyTable meta={props.widget} onRow={onRow} />
-            ) : props.widget.options.hierarchySameBc ? (
-                <SameBcHierarchyTable meta={props.widget} onRow={onRow} />
             ) : (
                 <HierarchyTable meta={props.widget} onRow={onRow} />
             )

--- a/src/epics/data/removeMultivalueTag.ts
+++ b/src/epics/data/removeMultivalueTag.ts
@@ -140,7 +140,7 @@ export function removeMultivalueTagImpl(
     }
     // Non-full hierarchies drops removed item's `_associate` flag`
     // And also updates source record value
-    if (widget.options?.hierarchy || widget.options?.hierarchySameBc) {
+    if (widget.options?.hierarchy) {
         return Observable.concat(
             Observable.of(
                 $do.changeDataItem({

--- a/src/utils/hierarchy.ts
+++ b/src/utils/hierarchy.ts
@@ -44,12 +44,13 @@ export function getColumnWidth(
     const indentLevel = depthLevel - 1
     // exclude hidden fields
     const showedFields = fields
-        ?.filter(item =>
-            rowMetaFields
-                ?.filter(i => !item.hidden)
-                ?.map(i => item.key)
-                ?.includes(item.key)
-        )
+        ?.filter(item => {
+            const rowMetaField = rowMetaFields?.find(itemRowMeta => itemRowMeta.key === item.key)
+            if (rowMetaField) {
+                return !rowMetaField.hidden
+            }
+            return true
+        })
         ?.filter(item => item.type !== FieldType.hidden)
         ?.filter(item => !item.hidden)
     const currentField = showedFields?.find(item => item.key === columnName)

--- a/yarn.lock
+++ b/yarn.lock
@@ -396,7 +396,7 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@tesler-ui/schema@^0.2.0":
+"@tesler-ui/schema@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@tesler-ui/schema/-/schema-0.2.0.tgz#b26a7460e630b278872335bb86784d660468bac8"
   integrity sha512-xHsCNGZ7CMaWgyMeDnZWv+VFdS98qFFt9nVJiXZ4z9KAYvAIKS53iWdXrtSpikB27ZanS4AeMRF88xkjBJw7Mg==


### PR DESCRIPTION
See #599
*  `<SameBcHierarchyTable />` deprecated
* `hierarchySameBc` widget option now will serve as a hint for a regular `<HierarchyTable />` to display indentation as if records on each level had the same set of fields (which is essentially was the purpose of `<SameBcHierarchyTable />` in the first place); handling of column width is now more similiar to `<FullHierarchyTable />` implementation
* `getColumnWidth` utility now does not require `rowMeta` to calculate column width those fixing position jumps during and after row meta fetch
* `@tesler-ui/schema` should be strict dependency
