### PR TITLE
lazy load erroneously applied to nested BC in hierarchies

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -165,7 +165,7 @@ export class ActionPayloadTypes {
         /**
          * The level of hierarchy to fetch data for
          *
-         * @deprecated TODO: 2.0.0 Should be all moved to separate hierarchy-specific action
+         * @deprecated Do not use; TODO: Will be removed in 2.0.0
          */
         depth?: number
         /**
@@ -822,6 +822,8 @@ export class ActionPayloadTypes {
     /**
      * Wrapper action to sets a cursor for the specified depth level of hierarchy widget
      * builded around a single business component and fetch children for that record.
+     *
+     * @deprecated Do not use. TODO: Will be removed in 2.0.0
      */
     bcSelectDepthRecord: {
         /**

--- a/src/epics/data/bcSelectDepthRecord.ts
+++ b/src/epics/data/bcSelectDepthRecord.ts
@@ -24,7 +24,7 @@ export const bcSelectDepthRecord: Epic = action$ =>
     })
 
 /**
- * Set a cursor when expanding a record in hierarchy widgets builded aroung single business components
+ * Set a cursor when expanding a record in hierarchy widgets builded around single business components
  * and fetch the data for children of expanded record.
  *
  * {@link ActionPayloadTypes.bcChangeDepthCursor | bcChangeDepthCursor} action is dispatched to set the cursor
@@ -37,6 +37,7 @@ export const bcSelectDepthRecord: Epic = action$ =>
  * TODO: There is no apparent reason why `widgetName` is empty; probably will be mandatory and replace `bcName` in 2.0.0.
  *
  * @param action This epic will fire on {@link ActionPayloadTypes.bcSelectDepthRecord | bcSelectDepthRecord} action
+ * @deprecated Do not use; TODO: Will be removed in 2.0.0
  * @category Epics
  */
 export function bcSelectDepthRecordImpl(action: ActionsMap['bcSelectDepthRecord']): Observable<AnyAction> {

--- a/src/reducers/__tests__/data.test.ts
+++ b/src/reducers/__tests__/data.test.ts
@@ -20,30 +20,6 @@ import { $do } from '../../actions/actions'
 import { data } from '../data'
 
 describe('data reducer', () => {
-    it('it sets new from payload on `bcFetchDataSuccess` except for hierarchies ', () => {
-        const state = {}
-        const item = { id: '9', vstamp: -1 }
-        const nextState = data(
-            state,
-            $do.bcFetchDataSuccess({
-                bcName: 'bcExample',
-                data: [item],
-                bcUrl: 'bcExample'
-            })
-        )
-        expect(nextState.bcExample).toEqual(expect.arrayContaining([item]))
-        const hierarchyNextState = data(
-            state,
-            $do.bcFetchDataSuccess({
-                bcName: 'bcExample',
-                data: [item],
-                bcUrl: 'bcExample',
-                depth: 2
-            })
-        )
-        expect(hierarchyNextState.bcExample).toBe(undefined)
-    })
-
     it('puts new record in the store for specified business component on `bcNewDataSuccess` action', () => {
         const existingDataItem = { id: '8', vstamp: -1 }
         const dataItem = { id: '9', vstamp: -1 }

--- a/src/reducers/data.ts
+++ b/src/reducers/data.ts
@@ -16,12 +16,10 @@ const emptyData: DataItem[] = []
 export function data(state = initialState, action: AnyAction) {
     switch (action.type) {
         case types.bcFetchDataSuccess: {
-            return action.payload.depth && action.payload.depth > 1
-                ? state
-                : {
-                      ...state,
-                      [action.payload.bcName]: action.payload.data
-                  }
+            return {
+                ...state,
+                [action.payload.bcName]: action.payload.data
+            }
         }
         case types.bcNewDataSuccess: {
             return {

--- a/src/reducers/screen.ts
+++ b/src/reducers/screen.ts
@@ -56,7 +56,6 @@ export function screen(state = initialState, action: AnyAction): ScreenState {
             return { ...state, screenName: action.payload.screenName, views: [] }
         }
         case types.bcFetchDataRequest: {
-            const depth = action.payload.depth
             return {
                 ...state,
                 bo: {
@@ -65,19 +64,7 @@ export function screen(state = initialState, action: AnyAction): ScreenState {
                         ...state.bo.bc,
                         [action.payload.bcName]: {
                             ...state.bo.bc[action.payload.bcName],
-                            ...(depth && depth > 1
-                                ? {
-                                      depthBc: {
-                                          ...state.bo.bc[action.payload.bcName].depthBc,
-                                          [depth]: {
-                                              ...(state.bo.bc[action.payload.bcName].depthBc || {})[depth],
-                                              loading: true
-                                          }
-                                      }
-                                  }
-                                : {
-                                      loading: true
-                                  })
+                            loading: true
                         }
                     }
                 }
@@ -120,7 +107,6 @@ export function screen(state = initialState, action: AnyAction): ScreenState {
             }
         }
         case types.bcFetchDataSuccess: {
-            const depth = action.payload.depth
             return {
                 ...state,
                 bo: {
@@ -129,20 +115,8 @@ export function screen(state = initialState, action: AnyAction): ScreenState {
                         ...state.bo.bc,
                         [action.payload.bcName]: {
                             ...state.bo.bc[action.payload.bcName],
-                            ...(depth && depth > 1
-                                ? {
-                                      depthBc: {
-                                          ...state.bo.bc[action.payload.bcName].depthBc,
-                                          [depth]: {
-                                              ...(state.bo.bc[action.payload.bcName].depthBc || {})[depth],
-                                              loading: false
-                                          }
-                                      }
-                                  }
-                                : {
-                                      hasNext: action.payload.hasNext,
-                                      loading: false
-                                  })
+                            hasNext: action.payload.hasNext,
+                            loading: false
                         }
                     }
                 },
@@ -153,7 +127,6 @@ export function screen(state = initialState, action: AnyAction): ScreenState {
             }
         }
         case types.bcFetchDataFail: {
-            const depth = action.payload.depth
             if (Object.values(state.bo.bc).some(bc => bc.name === action.payload.bcName)) {
                 return {
                     ...state,
@@ -163,19 +136,7 @@ export function screen(state = initialState, action: AnyAction): ScreenState {
                             ...state.bo.bc,
                             [action.payload.bcName]: {
                                 ...state.bo.bc[action.payload.bcName],
-                                ...(depth && depth > 1
-                                    ? {
-                                          depthBc: {
-                                              ...state.bo.bc[action.payload.bcName].depthBc,
-                                              [depth]: {
-                                                  ...(state.bo.bc[action.payload.bcName].depthBc || {})[depth],
-                                                  loading: false
-                                              }
-                                          }
-                                      }
-                                    : {
-                                          loading: false
-                                      })
+                                loading: false
                             }
                         }
                     },
@@ -311,6 +272,9 @@ export function screen(state = initialState, action: AnyAction): ScreenState {
                 cachedBc: { ...state.cachedBc, ...newCache }
             }
         }
+        /**
+         * @deprecated
+         */
         case types.bcChangeDepthCursor: {
             const bcName = action.payload.bcName
             const depth = action.payload.depth


### PR DESCRIPTION
1) Lazy widgets should not skip their fetch when they are shown
2) `parentOfNotLazyWidget` condition does not actually checked if widget is lazy or not, so any child widget matched
3) `anyHierarchyWidget` and `fullHierarchyWidget` condition checked bcName from action payload instead of widget, meaning requested from business components on ensted hierarchy levels were not detected as coming from hierarchy widget.

 All this contributed to hierarchies not showing expanded nodes content after https://github.com/tesler-platform/tesler-ui/pull/596 
 
 Additionally there is a clean up for reducers from `<SameBcHierarchyTable />` stuff and additional deprecation tags.