### PR TITLE
stale data fetch epic can crash the application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 1.28.3 (Febraury 20, 2021)
+
+## Fixes
+
+* Stale data fetch epic can crash the application.
+
 # Version 1.28.2 (Febraury 20, 2021)
 
 ## Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tesler-ui/core",
-  "version": "1.28.2",
+  "version": "1.28.3",
   "main": "tesler-ui-core.js",
   "homepage": "https://tesler.io/",
   "types": "index.d.ts",

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -673,10 +673,15 @@ export class ActionPayloadTypes {
     } = z
 
     /**
-     * TODO
+     * Closes currently active popup on view
      */
     closeViewPopup: {
-        bcName: string
+        /**
+         * Not used
+         *
+         * @deprecated TODO: Will be removed in 2.0.0
+         */
+        bcName?: string
     } = z
 
     /**

--- a/src/components/Widget/Widget.test.tsx
+++ b/src/components/Widget/Widget.test.tsx
@@ -189,7 +189,7 @@ describe('widget visibility', () => {
             store.dispatch($do.showViewPopup({ bcName: exampleBcName, widgetName: '1' }))
             wrapper.update()
             expect(wrapper.find(widgetNames[popupWidgetType]).length).toBe(1)
-            store.dispatch($do.closeViewPopup({ bcName: exampleBcName }))
+            store.dispatch($do.closeViewPopup(null))
             wrapper.update()
             expect(wrapper.find(widgetNames[popupWidgetType]).length).toBe(0)
         })

--- a/src/components/widgets/FlatTree/FlatTreePopup.tsx
+++ b/src/components/widgets/FlatTree/FlatTreePopup.tsx
@@ -83,11 +83,11 @@ export const FlatTreePopup: React.FC<FlatTreePopupProps> = props => {
     const handleConfirmMultiple = React.useCallback(() => {
         dispatch($do.saveAssociations({ bcNames: [bcName] }))
         dispatch($do.bcCancelPendingChanges({ bcNames: [bcName] }))
-        dispatch($do.closeViewPopup({ bcName }))
+        dispatch($do.closeViewPopup(null))
     }, [bcName])
 
     const handleCancelMultiple = React.useCallback(() => {
-        dispatch($do.closeViewPopup({ bcName }))
+        dispatch($do.closeViewPopup(null))
         dispatch($do.bcRemoveAllFilters({ bcName }))
         dispatch($do.bcCancelPendingChanges({ bcNames: [bcName] }))
     }, [bcName])

--- a/src/components/widgets/FlatTree/__tests__/FlatTreePopup.test.tsx
+++ b/src/components/widgets/FlatTree/__tests__/FlatTreePopup.test.tsx
@@ -131,7 +131,7 @@ describe('<FlatTreePopup />', () => {
             expect.objectContaining({
                 type: coreActions.closeViewPopup,
                 payload: {
-                    bcName: bcExample.name
+                    bcName: null
                 }
             })
         )

--- a/src/components/widgets/FlatTree/__tests__/FlatTreePopup.test.tsx
+++ b/src/components/widgets/FlatTree/__tests__/FlatTreePopup.test.tsx
@@ -130,9 +130,7 @@ describe('<FlatTreePopup />', () => {
         expect(dispatch).toHaveBeenCalledWith(
             expect.objectContaining({
                 type: coreActions.closeViewPopup,
-                payload: {
-                    bcName: null
-                }
+                payload: null
             })
         )
         expect(dispatch).toHaveBeenCalledWith(

--- a/src/components/widgets/FlatTree/useSingleSelect.ts
+++ b/src/components/widgets/FlatTree/useSingleSelect.ts
@@ -25,7 +25,7 @@ export function useSingleSelect(pickListDescriptor: PickMap, bcName: string, par
             })
             dispatch($do.changeDataItem({ bcName: parentBcName, cursor: parentCursor, dataItem }))
             dispatch($do.viewClearPickMap(null))
-            dispatch($do.closeViewPopup({ bcName }))
+            dispatch($do.closeViewPopup(null))
             dispatch($do.bcRemoveAllFilters({ bcName }))
         },
         [pickListDescriptor, parentCursor, bcName, parentBcName]

--- a/src/components/widgets/PickListPopup/PickListPopup.tsx
+++ b/src/components/widgets/PickListPopup/PickListPopup.tsx
@@ -200,7 +200,7 @@ const mapDispatchToProps = createMapDispatchToProps(
             },
             onClose: () => {
                 ctx.dispatch($do.viewClearPickMap(null))
-                ctx.dispatch($do.closeViewPopup({ bcName: ctx.props.bcName }))
+                ctx.dispatch($do.closeViewPopup(null))
                 ctx.dispatch($do.bcRemoveAllFilters({ bcName: ctx.props.bcName }))
             }
         }

--- a/src/epics/data/__tests__/bcFetchData.test.ts
+++ b/src/epics/data/__tests__/bcFetchData.test.ts
@@ -204,6 +204,14 @@ describe('bcFetchDataEpic', () => {
             )
         })
     })
+
+    it('does not breaks for missing widget', () => {
+        store.getState().view.widgets = []
+        const action = $do.bcFetchDataRequest({ widgetName: 'widget-example', bcName: 'bcExample' })
+        testEpic(flow(ActionsObservable.of(action), store), res => {
+            expect(res.length).toBe(0)
+        })
+    })
 })
 
 /** */

--- a/src/epics/data/bcFetchData.ts
+++ b/src/epics/data/bcFetchData.ts
@@ -69,6 +69,12 @@ export function bcFetchDataImpl(
      * through business component match
      */
     const widget = widgets.find(item => item.name === widgetName) ?? widgets.find(item => item.bcName === action.payload.bcName)
+    /**
+     * Missing widget means the view or screen were changed and data request is no longer relevant
+     */
+    if (!widget) {
+        return [Observable.empty()]
+    }
     const bcName = action.payload.bcName
     const bc = state.screen.bo.bc[bcName]
     const { cursor, page } = bc

--- a/src/epics/view/__tests__/fileUploadConfirm.test.ts
+++ b/src/epics/view/__tests__/fileUploadConfirm.test.ts
@@ -91,7 +91,7 @@ describe('fileUploadConfirm', () => {
             expect(result[2]).toEqual(
                 expect.objectContaining({
                     type: coreActions.closeViewPopup,
-                    payload: { bcName: 'bcExample' }
+                    payload: null
                 })
             )
         })

--- a/src/epics/view/fileUploadConfirm.ts
+++ b/src/epics/view/fileUploadConfirm.ts
@@ -68,7 +68,7 @@ export function fileUploadConfirmImpl(action: ActionsMap['bulkUploadFiles'], sto
         return Observable.concat(
             Observable.of($do.sendOperationSuccess({ bcName, cursor: null })),
             Observable.of($do.bcForceUpdate({ bcName })),
-            Observable.of($do.closeViewPopup({ bcName })),
+            Observable.of($do.closeViewPopup(null)),
             ...postOperationRoutine(widgetName, postInvoke, preInvoke, OperationTypeCrud.save, bcName)
         )
     })


### PR DESCRIPTION
When processing `bcFetchData` epic after navigating to a different view where the requesting widget is not present, epic will crash.

Additionally deprecate `bcName` payload for `closeViewPopup` action as it is not used and can't be realistically used as:
1) only one popup can be active on a view
2) not all popups on a view have business component