### PR TITLE
Info about Widget meta, BC and data shows near widget by enabling of debug mode

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -1134,6 +1134,11 @@ export class ActionPayloadTypes {
     } = z
 
     /**
+     * Enable/disable debug mode
+     */
+    switchDebugMode: boolean = z
+
+    /**
      * Download state to device
      */
     exportState: null = z
@@ -1142,6 +1147,18 @@ export class ActionPayloadTypes {
      * TODO
      */
     emptyAction: null = z
+
+    /**
+     * refresh screens, views and widgets meta
+     */
+    refreshMeta: null = z
+
+    /**
+     * Switch to another user role
+     */
+    switchRole: {
+        role: string
+    } = z
 }
 
 // action-types

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -199,6 +199,25 @@ export function getRmByForceActive(screenName: string, bcUrl: string, data: Pend
 }
 
 /**
+ * Request for refresh screens, views and widgets meta
+ *
+ * @category Tesler API Endpoints
+ */
+export function refreshMeta() {
+    return axiosGet(buildUrl`bc-registry/refresh-meta`)
+}
+
+/**
+ * Request for role switching
+ *
+ * @param role Code of new role
+ * @category Tesler API Endpoints
+ */
+export function loginByRoleRequest(role: string) {
+    return axiosGet(buildUrl`login?role=${role}`)
+}
+
+/**
  * Returns new cancel token and cancel callback
  */
 export function createCanceler() {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 export {
+    loginByRoleRequest,
+    refreshMeta,
     fetchBcData,
     fetchBcDataAll,
     fetchRowMeta,

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -7,6 +7,8 @@
         "Details": "Details",
         "Error": "Error",
         "Error code": "Error code",
+        "Invalid credentials": "Invalid credentials",
+        "Access denied": "Access denied",
         "Show all records": "Show all records",
         "Clear all filters": "Clear all filters",
         "Cancel": "Cancel",
@@ -28,10 +30,12 @@
         "System error has been occurred": "System error has been occurred",
         "There is no connection to the server": "There is no connection to the server",
         "Load more": "Load more",
+        "Refresh meta": "Refresh meta",
         "Required fields are missing": "Required fields are missing",
         "This field is mandatory": "This field is mandatory",
         "Enter value": "Enter value",
         "Save info for developers": "Save info for developers",
+        "Show meta": "Show meta",
         "Screen is missing or unavailable for your role": "Screen {{screenName}} is missing or unavailable for your role",
         "View is missing or unavailable for your role": "View {{viewName}} is missing or unavailable for your role"
     }

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -7,6 +7,8 @@
         "Details": "Подробности",
         "Error": "Ошибка",
         "Error code": "Код ошибки",
+        "Invalid credentials": "Неверные учетные данные",
+        "Access denied": "Доступ запрещен",
         "Required fields are missing": "Не заполнены обязательные поля",
         "This field is mandatory": "Поле обязательно для заполнения",
         "There are pending changes. Please save them or cancel.": "Остались несохраненные данные. Сохраните или отмените изменения.",
@@ -33,7 +35,9 @@
         "There is no connection to the server": "Отсутствует связь с сервером",
         "Load more": "Загрузить еще",
         "Enter value": "Введите значение",
+        "Refresh meta": "Обновить мета данные",
         "Save info for developers": "Сохранить информацию для разработчиков",
+        "Show meta": "Показать мета данные",
         "Screen is missing or unavailable for your role": "Экран \"{{screenName}}\" отсутствует или недоступен для вашей роли",
         "View is missing or unavailable for your role": "Панель \"{{viewName}}\" отсутствует или недоступна для вашей роли"
     }

--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { Collapse } from 'antd'
+import { useSelector } from 'react-redux'
+import { Store } from '../../interfaces/store'
+import { WidgetMeta } from '../../interfaces/widget'
+import FormattedJSON from './components/FormattedJSON'
+import WidgetInfoLabel from './components/WidgetInfoLabel'
+
+interface DebugPanelProps {
+    widgetMeta: WidgetMeta
+}
+
+const DebugPanel: React.FunctionComponent<DebugPanelProps> = props => {
+    const { widgetMeta } = props
+    const { Panel } = Collapse
+    const widget = useSelector((store: Store) => store.view.widgets.find(i => i.name === widgetMeta.name))
+    const bc = useSelector((store: Store) => store.screen.bo.bc[widgetMeta.bcName])
+    const data = useSelector((store: Store) => store.data[widgetMeta.bcName])
+    const widgetText = `"name": "${widget.name ?? ''}"`
+    const titleText = `"title": "${widget.title ?? ''}"`
+    const bcText = `"bc": "${widget.bcName ?? ''}"`
+    const infoList = [widgetText, titleText, bcText]
+    return (
+        <>
+            <WidgetInfoLabel infoList={infoList} />
+            <Collapse>
+                <Panel header="Widget" key="widgetDebug">
+                    <FormattedJSON json={(widget as unknown) as Record<string, unknown>} />
+                </Panel>
+                <Panel header="BC" key="bcDebug">
+                    <FormattedJSON json={(bc as unknown) as Record<string, unknown>} />
+                </Panel>
+                <Panel header="Data" key="dataDebug">
+                    <FormattedJSON json={(data as unknown) as Record<string, unknown>} />
+                </Panel>
+            </Collapse>
+        </>
+    )
+}
+
+const MemoizedDebugPanel = React.memo(DebugPanel)
+export default MemoizedDebugPanel

--- a/src/components/DebugPanel/__tests__/DebugPanel.test.tsx
+++ b/src/components/DebugPanel/__tests__/DebugPanel.test.tsx
@@ -1,0 +1,60 @@
+import { mount } from 'enzyme'
+import React from 'react'
+import DebugPanel from '../DebugPanel'
+import { WidgetMeta, WidgetTypes } from '../../../interfaces/widget'
+import { Collapse } from 'antd'
+import { Store } from 'redux'
+import { Store as CoreStore } from '../../../interfaces/store'
+import { mockStore } from '../../../tests/mockStore'
+import { Provider } from 'react-redux'
+import { BcMetaState } from '../../../interfaces/bc'
+import { DataItem } from '@tesler-ui/schema'
+
+describe('DebugPanel testing', () => {
+    let store: Store<CoreStore> = null
+    const exampleBcName = 'bcExample'
+    const widgetMeta: WidgetMeta = {
+        name: 'name',
+        bcName: exampleBcName,
+        type: WidgetTypes.List,
+        title: 'title',
+        position: 1,
+        gridWidth: 2,
+        fields: []
+    }
+    const bc: BcMetaState = {
+        url: 'standard',
+        defaultFilter: '',
+        filterGroups: null,
+        defaultSort: null,
+        cursor: '4229649',
+        page: 1,
+        limit: 20,
+        hasNext: true,
+        parentName: null,
+        name: exampleBcName,
+        loading: false
+    }
+    const data: DataItem[] = [
+        {
+            id: '4229649',
+            vstamp: 7
+        }
+    ]
+    const widgets: WidgetMeta[] = [widgetMeta]
+    beforeAll(() => {
+        store = mockStore()
+        store.getState().view.widgets = widgets
+        store.getState().screen.bo.bc[exampleBcName] = bc
+        store.getState().data[exampleBcName] = data
+    })
+
+    it('should render', () => {
+        const wrapper = mount(
+            <Provider store={store}>
+                <DebugPanel widgetMeta={widgetMeta} />
+            </Provider>
+        )
+        expect(wrapper.find(Collapse).length).toBe(1)
+    })
+})

--- a/src/components/DebugPanel/components/FormattedJSON.tsx
+++ b/src/components/DebugPanel/components/FormattedJSON.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import highlightJson from '../../../utils/highlightJson'
+
+interface FormattedJSONProps {
+    json: Record<string, unknown>
+}
+const FormattedJSON: React.FunctionComponent<FormattedJSONProps> = props => {
+    const { json } = props
+    return (
+        <pre>
+            <code dangerouslySetInnerHTML={{ __html: highlightJson(json) }} />
+        </pre>
+    )
+}
+
+const MemoizedFormattedJSON = React.memo(FormattedJSON)
+export default MemoizedFormattedJSON

--- a/src/components/DebugPanel/components/InfoLabel.less
+++ b/src/components/DebugPanel/components/InfoLabel.less
@@ -1,0 +1,8 @@
+
+.wrapper {
+    margin-right: 5px;
+}
+
+.container {
+    margin-bottom: 5px;
+}

--- a/src/components/DebugPanel/components/InfoLabel.tsx
+++ b/src/components/DebugPanel/components/InfoLabel.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import CopyableText from '../../ui/CopyableText/CopyableText'
+import styles from './InfoLabel.less'
+
+interface InfoLabelProps {
+    label: string
+    info: string[]
+}
+const InfoLabel: React.FunctionComponent<InfoLabelProps> = props => {
+    const { label, info } = props
+    return (
+        <div className={styles.container}>
+            <span className={styles.wrapper}>{label}</span>
+            {info.map(i => (
+                <CopyableText className={styles.wrapper} text={i} key={i} />
+            ))}
+        </div>
+    )
+}
+const MemoizedInfoLabel = React.memo(InfoLabel)
+export default MemoizedInfoLabel

--- a/src/components/DebugPanel/components/ViewInfoLabel.less
+++ b/src/components/DebugPanel/components/ViewInfoLabel.less
@@ -1,0 +1,3 @@
+.container {
+    display: flex;
+}

--- a/src/components/DebugPanel/components/ViewInfoLabel.tsx
+++ b/src/components/DebugPanel/components/ViewInfoLabel.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import InfoLabel from './InfoLabel'
+import { useSelector } from 'react-redux'
+import { Store } from '../../../interfaces/store'
+import styles from './ViewInfoLabel.less'
+
+const ViewInfoLabel: React.FunctionComponent = () => {
+    const screenName = useSelector((store: Store) => store.screen.screenName) ?? ''
+    const viewName = useSelector((store: Store) => store.view.name) ?? ''
+    const screenInfo = [`"name": "${screenName}"`]
+    const viewInfo = [`"name": "${viewName}"`]
+    return (
+        <div className={styles.container}>
+            <InfoLabel label="Screen" info={screenInfo} />
+            <InfoLabel label="View" info={viewInfo} />
+        </div>
+    )
+}
+
+const MemoizedViewInfoLabel = React.memo(ViewInfoLabel)
+export default MemoizedViewInfoLabel

--- a/src/components/DebugPanel/components/WidgetInfoLabel.tsx
+++ b/src/components/DebugPanel/components/WidgetInfoLabel.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import InfoLabel from './InfoLabel'
+
+const WidgetInfoLabel: React.FunctionComponent<{ infoList: string[] }> = ({ infoList }) => {
+    return <InfoLabel label="Widget" info={infoList} />
+}
+
+const MemoizedWidgetInfoLabel = React.memo(WidgetInfoLabel)
+export default MemoizedWidgetInfoLabel

--- a/src/components/DebugPanel/components/__tests__/FormattedJSON.test.tsx
+++ b/src/components/DebugPanel/components/__tests__/FormattedJSON.test.tsx
@@ -1,0 +1,20 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import FormattedJSON from '../FormattedJSON'
+
+describe('FormattedJSON testing', () => {
+    const ex = {
+        name: 'name',
+        bcName: 'exampleBcName',
+        type: 'List',
+        title: 'title',
+        position: 1,
+        gridWidth: 2,
+        fields: [] as any
+    }
+
+    it('should render', () => {
+        const wrapper = shallow(<FormattedJSON json={ex} />)
+        expect(wrapper.find('code').length).toBe(1)
+    })
+})

--- a/src/components/DebugPanel/components/__tests__/InfoLabel.test.tsx
+++ b/src/components/DebugPanel/components/__tests__/InfoLabel.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import InfoLabel from '../InfoLabel'
+
+describe('InfoLabel', () => {
+    it('should render', () => {
+        const info = ['some info']
+        const label = 'Some label'
+        const wrapper = shallow(<InfoLabel info={info} label={label} />)
+        expect(wrapper.find('span').findWhere(i => i.text() === label).length).toBeGreaterThan(0)
+        expect(wrapper.find('Memo(CopyableText)').length).toBe(info.length)
+    })
+})

--- a/src/components/DebugPanel/components/__tests__/ViewInfoLabel.test.tsx
+++ b/src/components/DebugPanel/components/__tests__/ViewInfoLabel.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { mockStore } from '../../../../tests/mockStore'
+import { Store as CoreStore } from '../../../../interfaces/store'
+import { Store } from 'redux'
+import { Provider } from 'react-redux'
+import ViewInfoLabel from '../ViewInfoLabel'
+
+describe('ViewInfoLabel', () => {
+    let store: Store<CoreStore> = null
+
+    beforeAll(() => {
+        store = mockStore()
+        store.getState().screen.screenName = 'some screen name'
+        store.getState().view.name = 'some view name'
+    })
+
+    it('should render', () => {
+        const wrapper = mount(
+            <Provider store={store}>
+                <ViewInfoLabel />
+            </Provider>
+        )
+        expect(wrapper.find('span').findWhere(i => i.text() === 'Screen').length).toBeGreaterThan(0)
+        expect(wrapper.find('span').findWhere(i => i.text() === 'View').length).toBeGreaterThan(0)
+    })
+})

--- a/src/components/DebugPanel/components/__tests__/WidgetInfoLabel.test.tsx
+++ b/src/components/DebugPanel/components/__tests__/WidgetInfoLabel.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import WidgetInfoLabel from '../WidgetInfoLabel'
+
+describe('WidgetInfoLabel', () => {
+    it('should render', () => {
+        const info = ['some info']
+        const wrapper = shallow(<WidgetInfoLabel infoList={info} />)
+        expect(wrapper.find('Memo(InfoLabel)').findWhere(i => i.props().label === 'Widget').length).toBe(1)
+    })
+})

--- a/src/components/DevToolsPanel/DevToolsPanel.less
+++ b/src/components/DevToolsPanel/DevToolsPanel.less
@@ -1,0 +1,39 @@
+.container {
+    background: #3d4042;
+
+    :global {
+        .ant-layout-header {
+            padding: 0 30px;
+            height: 30px;
+            line-height: 30px;
+            background: transparent;
+        }
+        .ant-btn {
+            border: none;
+            background-color: transparent;
+            border-radius: 0;
+            color: white;
+
+            &:hover {
+                background-color: #525867;
+            }
+            &:active {
+                background-color: #525867;
+            }
+            &:focus {
+                background-color: #525867;
+            }
+            &:active {
+                background-color: #636773;
+            }
+        }
+    }
+}
+
+.wrapper {
+    margin-right: 5px;
+}
+
+.controlsWrapper {
+    display: flex;
+}

--- a/src/components/DevToolsPanel/DevToolsPanel.test.tsx
+++ b/src/components/DevToolsPanel/DevToolsPanel.test.tsx
@@ -1,0 +1,19 @@
+import { shallow } from 'enzyme'
+import DevToolsPanel from './DevToolsPanel'
+import React from 'react'
+import { Button } from 'antd'
+
+describe('DevToolsPanel', () => {
+    it('should render buttons and client controls', () => {
+        const wrapper = shallow(
+            <DevToolsPanel>
+                <Button icon="icon-close" />
+                <Button icon="down-circle" />
+            </DevToolsPanel>
+        )
+        expect(wrapper.find('Memo(RefreshMetaButton)').length).toBe(1)
+        expect(wrapper.find('Memo(DebugModeButton)').length).toBe(1)
+        expect(wrapper.find('Button').findWhere(i => i.props().icon === 'icon-close').length).toBe(1)
+        expect(wrapper.find('Button').findWhere(i => i.props().icon === 'down-circle').length).toBe(1)
+    })
+})

--- a/src/components/DevToolsPanel/DevToolsPanel.tsx
+++ b/src/components/DevToolsPanel/DevToolsPanel.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Layout as AntLayout } from 'antd'
+import styles from './DevToolsPanel.less'
+import RefreshMetaButton from './components/RefreshMetaButton'
+import DebugModeButton from './components/DebugModeButton'
+import cn from 'classnames'
+
+interface DevToolsPanelProps {
+    className?: string
+    children?: React.ReactNode
+}
+
+/**
+ * Dev tools panel
+ */
+const DevToolsPanel: React.FunctionComponent<DevToolsPanelProps> = ({ children, className }) => {
+    return (
+        <div className={cn(styles.container, className)}>
+            <AntLayout.Header>
+                <div className={styles.controlsWrapper}>
+                    <RefreshMetaButton className={styles.wrapper} key="RefreshMetaButton" />
+                    <DebugModeButton className={styles.wrapper} key="DebugModeButton" />
+                    {children}
+                </div>
+            </AntLayout.Header>
+        </div>
+    )
+}
+/**
+ * @category Components
+ */
+export const MemoizedDevToolsPanel = React.memo(DevToolsPanel)
+
+export default MemoizedDevToolsPanel

--- a/src/components/DevToolsPanel/components/DebugModeButton.tsx
+++ b/src/components/DevToolsPanel/components/DebugModeButton.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Store } from 'interfaces/store'
+import { Button, Tooltip } from 'antd'
+import { $do } from '../../../actions/actions'
+import { useDispatch, useSelector } from 'react-redux'
+import { useTranslation } from 'react-i18next'
+
+interface DebugModeButtonProps {
+    className?: string
+}
+
+const DebugModeButton: React.FunctionComponent<DebugModeButtonProps> = props => {
+    const { className } = props
+    const dispatch = useDispatch()
+    const mode = useSelector((store: Store) => store.session.debugMode)
+    const handleDebugMode = React.useCallback(() => dispatch($do.switchDebugMode(!mode)), [dispatch, mode])
+    const { t } = useTranslation()
+    const tooltipTitle = t('Show meta')
+
+    return (
+        <div className={className}>
+            <Tooltip title={tooltipTitle}>
+                <Button icon="bug" onClick={handleDebugMode} />
+            </Tooltip>
+        </div>
+    )
+}
+
+/**
+ * @category Components
+ */
+const MemoizedDebugModeButton = React.memo(DebugModeButton)
+
+export default MemoizedDebugModeButton

--- a/src/components/DevToolsPanel/components/RefreshMetaButton.tsx
+++ b/src/components/DevToolsPanel/components/RefreshMetaButton.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { $do } from '../../../actions/actions'
+import { Button, Tooltip } from 'antd'
+import { useTranslation } from 'react-i18next'
+import { useDispatch } from 'react-redux'
+
+interface RefreshMetaButtonProps {
+    className?: string
+}
+
+const RefreshMetaButton: React.FunctionComponent<RefreshMetaButtonProps> = props => {
+    const { className } = props
+    const dispatch = useDispatch()
+    const handleRefreshMeta = React.useCallback(() => {
+        dispatch($do.refreshMeta(null))
+    }, [dispatch])
+    const { t } = useTranslation()
+    return (
+        <div className={className}>
+            <Tooltip title={t('Refresh meta')}>
+                <Button onClick={handleRefreshMeta} icon="sync" />
+            </Tooltip>
+        </div>
+    )
+}
+
+/**
+ * @category Components
+ */
+export const MemoizedRefreshMetaButton = React.memo(RefreshMetaButton)
+
+export default MemoizedRefreshMetaButton

--- a/src/components/DevToolsPanel/components/__tests__/DebugModeButton.test.tsx
+++ b/src/components/DevToolsPanel/components/__tests__/DebugModeButton.test.tsx
@@ -1,0 +1,37 @@
+import { mount } from 'enzyme'
+import { Provider } from 'react-redux'
+import { Store as CoreStore } from 'interfaces/store'
+import { mockStore } from '../../../../tests/mockStore'
+import { Store } from 'redux'
+import React from 'react'
+import DebugModeButton from '../DebugModeButton'
+import { $do } from '../../../../actions/actions'
+
+describe('DebugModeButton', () => {
+    let store: Store<CoreStore> = null
+    const dispatchMock = jest.fn()
+
+    beforeAll(() => {
+        store = mockStore()
+        store.getState().session.debugMode = true
+    })
+    beforeEach(() => {
+        jest.spyOn(store, 'dispatch').mockImplementation(dispatchMock)
+    })
+    afterEach(() => {
+        dispatchMock.mockRestore()
+    })
+
+    it('should render and handle click', () => {
+        const wrapper = mount(
+            <Provider store={store}>
+                <DebugModeButton />
+            </Provider>
+        )
+        const button = wrapper.find('Button').findWhere(i => i.props().icon === 'bug')
+        expect(button.length).toBe(1)
+        expect(wrapper.find('Tooltip').findWhere(i => i.props().title === 'Show meta').length).toBeGreaterThan(0)
+        button.simulate('click')
+        expect(dispatchMock).toHaveBeenCalledWith(expect.objectContaining($do.switchDebugMode(false)))
+    })
+})

--- a/src/components/DevToolsPanel/components/__tests__/RefreshMetaButton.test.tsx
+++ b/src/components/DevToolsPanel/components/__tests__/RefreshMetaButton.test.tsx
@@ -1,0 +1,34 @@
+import { Store } from 'redux'
+import { Store as CoreStore } from '../../../../interfaces/store'
+import { mockStore } from '../../../../tests/mockStore'
+import { mount } from 'enzyme'
+import { Provider } from 'react-redux'
+import React from 'react'
+import RefreshMetaButton from '../RefreshMetaButton'
+import { $do } from '../../../../actions/actions'
+
+describe('RefreshMetaButton', () => {
+    let store: Store<CoreStore> = null
+    const dispatchMock = jest.fn()
+
+    beforeAll(() => {
+        store = mockStore()
+    })
+    beforeEach(() => {
+        jest.spyOn(store, 'dispatch').mockImplementation(dispatchMock)
+    })
+    afterEach(() => {
+        dispatchMock.mockRestore()
+    })
+    it('should render button and handle click', () => {
+        const wrapper = mount(
+            <Provider store={store}>
+                <RefreshMetaButton />
+            </Provider>
+        )
+        const button = wrapper.find('Button').findWhere(i => i.props().icon === 'sync')
+        expect(wrapper.find('Tooltip').findWhere(i => i.props().title === 'Refresh meta').length).toBeGreaterThan(0)
+        button.simulate('click')
+        expect(dispatchMock).toHaveBeenCalledWith(expect.objectContaining($do.refreshMeta(null)))
+    })
+})

--- a/src/components/View/View.tsx
+++ b/src/components/View/View.tsx
@@ -1,11 +1,14 @@
 import React, { FunctionComponent } from 'react'
 import { connect, useSelector } from 'react-redux'
 import { Store } from '../../interfaces/store'
-import { CustomWidget, CustomWidgetDescriptor, WidgetMeta } from '../../interfaces/widget'
+import { CustomWidget, CustomWidgetDescriptor, PopupWidgetTypes, WidgetMeta } from '../../interfaces/widget'
 import DashboardLayout from '../ui/DashboardLayout/DashboardLayout'
 import { FileUploadPopup } from '../../components/FileUploadPopup/FileUploadPopup'
+import ViewInfoLabel from '../DebugPanel/components/ViewInfoLabel'
+import DebugPanel from '../DebugPanel/DebugPanel'
 
 export interface ViewProps {
+    debugMode?: boolean
     widgets: WidgetMeta[]
     skipWidgetTypes?: string[]
     card?: (props: any) => React.ReactElement<any>
@@ -27,40 +30,44 @@ export const CustomizationContext: React.Context<{
  * @category Components
  */
 export const View: FunctionComponent<ViewProps> = props => {
+    const { debugMode, widgets, skipWidgetTypes, card, customSpinner, customWidgets, customLayout, customFields } = props
     let layout: React.ReactNode = null
     const fileUploadPopup = useSelector((state: Store) => state.view.popupData?.type === 'file-upload')
-    if (props.customLayout) {
+    if (customLayout) {
         layout = (
             <props.customLayout
-                customSpinner={props.customSpinner}
-                widgets={props.widgets}
-                customWidgets={props.customWidgets}
-                card={props.card}
-                skipWidgetTypes={props.skipWidgetTypes}
+                customSpinner={customSpinner}
+                widgets={widgets}
+                customWidgets={customWidgets}
+                card={card}
+                skipWidgetTypes={skipWidgetTypes}
             />
         )
     } else {
         layout = (
             <DashboardLayout
-                customSpinner={props.customSpinner}
-                widgets={props.widgets}
-                customWidgets={props.customWidgets}
-                card={props.card}
-                skipWidgetTypes={props.skipWidgetTypes}
+                customSpinner={customSpinner}
+                widgets={widgets}
+                customWidgets={customWidgets}
+                card={card}
+                skipWidgetTypes={skipWidgetTypes}
             />
         )
     }
 
     return (
-        <CustomizationContext.Provider value={{ customFields: props.customFields }}>
+        <CustomizationContext.Provider value={{ customFields: customFields }}>
+            {debugMode && <ViewInfoLabel />}
             {fileUploadPopup && <FileUploadPopup />}
             {layout}
+            {debugMode && widgets.filter(i => PopupWidgetTypes.includes(i.type)).map(i => <DebugPanel key={i.name} widgetMeta={i} />)}
         </CustomizationContext.Provider>
     )
 }
 
 function mapStateToProps(store: Store) {
     return {
+        debugMode: store.session.debugMode,
         widgets: store.view.widgets
     }
 }

--- a/src/components/View/__tests__/View.test.tsx
+++ b/src/components/View/__tests__/View.test.tsx
@@ -7,6 +7,8 @@ import { Provider } from 'react-redux'
 import { WidgetMeta, WidgetTypes } from '../../../interfaces/widget'
 import { mockStore } from '../../../tests/mockStore'
 import { DashboardLayout } from '../../index'
+import DebugPanel from '../../DebugPanel/DebugPanel'
+import ViewInfoLabel from '../../DebugPanel/components/ViewInfoLabel'
 
 describe('View testing', () => {
     let store: Store<CoreStore> = null
@@ -16,6 +18,15 @@ describe('View testing', () => {
             name: 'name',
             bcName: 'bcName',
             type: WidgetTypes.List,
+            title: 'title',
+            position: 1,
+            gridWidth: 2,
+            fields: []
+        },
+        {
+            name: 'popupName',
+            bcName: 'bcName',
+            type: WidgetTypes.PickListPopup,
             title: 'title',
             position: 1,
             gridWidth: 2,
@@ -60,5 +71,16 @@ describe('View testing', () => {
             </Provider>
         )
         expect(wrapper.find(DashboardLayout).props().customSpinner === customSpinner).toBeTruthy()
+    })
+
+    it('should render developer info', () => {
+        store.getState().session.debugMode = true
+        const wrapper = mount(
+            <Provider store={store}>
+                <View />
+            </Provider>
+        )
+        expect(wrapper.find(ViewInfoLabel).length).toBe(1)
+        expect(wrapper.find(DebugPanel).length).toBe(widgets.length)
     })
 })

--- a/src/components/Widget/Widget.tsx
+++ b/src/components/Widget/Widget.tsx
@@ -24,6 +24,7 @@ import { DataState } from '../../interfaces/data'
 import { buildBcUrl } from '../../utils/strings'
 import FlatTreePopup from '../widgets/FlatTree/FlatTreePopup'
 import FlatTree from '../widgets/FlatTree/FlatTree'
+import DebugPanel from '../DebugPanel/DebugPanel'
 
 interface WidgetOwnProps {
     meta: WidgetMeta | WidgetMetaAny
@@ -33,6 +34,7 @@ interface WidgetOwnProps {
 }
 
 interface WidgetProps extends WidgetOwnProps {
+    debugMode?: boolean
     loading?: boolean
     parentCursor?: string
     customWidgets?: Record<string, CustomWidgetDescriptor>
@@ -91,6 +93,7 @@ export const Widget: FunctionComponent<WidgetProps> = props => {
             <Card meta={props.meta}>
                 {showSkeleton && <Skeleton loading paragraph={skeletonParams} />}
                 {!showSkeleton && spinnerElement}
+                {props.debugMode && <DebugPanel widgetMeta={props.meta} />}
             </Card>
         )
     }
@@ -99,6 +102,7 @@ export const Widget: FunctionComponent<WidgetProps> = props => {
             <h2 className={styles.title}>{props.meta.title}</h2>
             {showSkeleton && <Skeleton loading paragraph={skeletonParams} />}
             {!showSkeleton && spinnerElement}
+            {props.debugMode && <DebugPanel widgetMeta={props.meta} />}
         </div>
     )
 }
@@ -165,6 +169,7 @@ function mapStateToProps(store: Store, ownProps: WidgetOwnProps) {
     const bcUrl = buildBcUrl(bcName, true)
     const rowMeta = bcUrl && store.view.rowMeta[bcName]?.[bcUrl]
     return {
+        debugMode: store.session.debugMode,
         loading: bc?.loading,
         parentCursor: hasParent && parent.cursor,
         showWidget,

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -42,3 +42,5 @@ export { default as AssocListPopup } from './widgets/AssocListPopup/AssocListPop
 export { default as PickListPopup } from './widgets/PickListPopup/PickListPopup'
 export { default as FlatTree } from './widgets/FlatTree/FlatTree'
 export { default as FlatTreePopup } from './widgets/FlatTree/FlatTreePopup'
+// Developer
+export { default as DevToolsPanel } from './DevToolsPanel/DevToolsPanel'

--- a/src/components/ui/CopyableText/CopyableText.tsx
+++ b/src/components/ui/CopyableText/CopyableText.tsx
@@ -1,0 +1,29 @@
+import React, { CSSProperties } from 'react'
+import { Icon, Input } from 'antd'
+
+interface CopyableTextProps {
+    text: string
+    className?: string
+}
+
+const CopyableText: React.FunctionComponent<CopyableTextProps> = props => {
+    const { text, className } = props
+    const textRef = React.useRef(null)
+    const handleCopyDetails = React.useCallback(() => {
+        textRef.current.select()
+        document.execCommand('copy')
+    }, [textRef])
+    const inputStyle: CSSProperties = { width: 300 }
+    return (
+        <Input
+            className={className}
+            size="small"
+            ref={textRef}
+            value={text}
+            style={inputStyle}
+            addonAfter={<Icon type="copy" onClick={handleCopyDetails} />}
+        />
+    )
+}
+
+export default React.memo(CopyableText)

--- a/src/components/ui/CopyableText/__tests__/CopyableText.test.tsx
+++ b/src/components/ui/CopyableText/__tests__/CopyableText.test.tsx
@@ -1,0 +1,10 @@
+import { shallow } from 'enzyme'
+import CopyableText from '../CopyableText'
+import React from 'react'
+
+describe('CopyableText', () => {
+    const wrapper = shallow(<CopyableText text="some text" />)
+    it('should render Input', () => {
+        expect(wrapper.find('Input').length).toBe(1)
+    })
+})

--- a/src/epics/router/__tests__/changeLocation.test.ts
+++ b/src/epics/router/__tests__/changeLocation.test.ts
@@ -217,6 +217,7 @@ const defaultView: ViewMetaResponse = {
 
 const requestedScreen: SessionScreen = {
     id: null,
+    primary: 'view-default',
     name: 'screen-next',
     text: 'Next Screen',
     url: 'screen/screen-next'
@@ -224,6 +225,7 @@ const requestedScreen: SessionScreen = {
 
 const defaultScreen: SessionScreen = {
     id: null,
+    primary: 'view-default',
     name: 'screen-default',
     text: 'Default Screen',
     url: 'screen/screen-default',

--- a/src/epics/session.ts
+++ b/src/epics/session.ts
@@ -1,5 +1,11 @@
 import { loginEpic } from './session/loginDone'
+import { refreshMetaEpic } from './session/refreshMeta'
+import { loginByAnotherRoleEpic } from './session/loginByAnotherRole'
+import { switchRoleEpic } from './session/switchRole'
 
 export const sessionEpics = {
+    loginByAnotherRoleEpic,
+    refreshMetaEpic,
+    switchRoleEpic,
     loginEpic
 }

--- a/src/epics/session/__tests__/__mocks__/response.json
+++ b/src/epics/session/__tests__/__mocks__/response.json
@@ -1,0 +1,389 @@
+{
+  "sessionId": "111111",
+  "userId": 1,
+  "login": "vanilla",
+  "lastName": "Snow",
+  "firstName": "John",
+  "patronymic": "Snowich",
+  "fullName": "Snow John Snowich",
+  "principalName": "vanilla@sbl.local",
+  "phone": "+49-163-5553-408",
+  "activeRole": "ADMIN",
+  "roles": [
+    {
+      "type": null,
+      "key": "ADMIN",
+      "value": "Administrator",
+      "description": null,
+      "language": null,
+      "displayOrder": null,
+      "active": true,
+      "cacheLoaderName": null
+    },
+    {
+      "type": null,
+      "key": "Auditor",
+      "value": "Auditor",
+      "description": null,
+      "language": null,
+      "displayOrder": null,
+      "active": true,
+      "cacheLoaderName": null
+    }
+  ],
+  "screens": [
+    {
+      "id": "id1",
+      "name": "dashboard",
+      "text": "Dashboard",
+      "url": "/screen/dashboard",
+      "icon": "bar-chart",
+      "defaultScreen": false,
+      "meta": {
+        "id": "1289810",
+        "errors": null,
+        "vstamp": 0,
+        "name": "dashboard",
+        "title": "Dashboard",
+        "primary": "dashboard",
+        "views": [
+          {
+            "id": 1289724,
+            "name": "dashboard",
+            "template": "Dashboard",
+            "title": "Dashboard",
+            "url": "/screen/dashboard/view/dashboard",
+            "customizable": false,
+            "editable": false,
+            "widgets": [
+              {
+                "id": "1290278",
+                "errors": null,
+                "vstamp": 0,
+                "name": "dashboardHeader",
+                "widgetId": 0,
+                "position": 1,
+                "descriptionTitle": null,
+                "description": null,
+                "snippet": null,
+                "showExportStamp": false,
+                "limit": 0,
+                "type": "Header",
+                "url": "dashboard",
+                "bcName": "dashboard",
+                "title": "Dashboard",
+                "fields": [],
+                "options": {},
+                "pivotFields": null,
+                "axisFields": [],
+                "showCondition": [],
+                "chart": [],
+                "graph": null,
+                "x": null,
+                "y": null,
+                "width": null,
+                "height": null,
+                "minHeight": null,
+                "maxHeight": null,
+                "minWidth": null,
+                "maxWidth": null,
+                "isDraggable": null,
+                "isResizable": null,
+                "gridWidth": 2,
+                "gridBreak": 0,
+                "hide": false
+              }
+            ],
+            "columns": null,
+            "rowHeight": null,
+            "readOnly": false,
+            "ignoreHistory": false,
+            "options": []
+          },
+          {
+            "id": 1289725,
+            "name": "dashboardoutlet",
+            "template": "DashboardView",
+            "title": "Outlet",
+            "url": "/screen/dashboard/view/dashboardoutlet",
+            "customizable": false,
+            "editable": false,
+            "widgets": [
+              {
+                "id": "1289920",
+                "errors": null,
+                "vstamp": 0,
+                "name": "dashboardReturnToDashboardView",
+                "widgetId": 0,
+                "position": 0,
+                "descriptionTitle": null,
+                "description": null,
+                "snippet": null,
+                "showExportStamp": false,
+                "limit": 0,
+                "type": "Form",
+                "url": "dashboard",
+                "bcName": "dashboard",
+                "title": null,
+                "fields": [],
+                "options": {
+                  "actionGroups": {
+                    "include": [
+                      "back-to-dashboard"
+                    ]
+                  }
+                },
+                "pivotFields": null,
+                "axisFields": [],
+                "showCondition": [],
+                "chart": [],
+                "graph": null,
+                "x": null,
+                "y": null,
+                "width": null,
+                "height": null,
+                "minHeight": null,
+                "maxHeight": null,
+                "minWidth": null,
+                "maxWidth": null,
+                "isDraggable": null,
+                "isResizable": null,
+                "gridWidth": 2,
+                "gridBreak": 0,
+                "hide": false
+              }
+            ],
+            "columns": null,
+            "rowHeight": null,
+            "readOnly": false,
+            "ignoreHistory": false,
+            "options": []
+          }
+        ],
+        "bo": {
+          "bc": [
+            {
+              "id": null,
+              "url": "dashboard",
+              "defaultFilter": null,
+              "dimFilterSpec": null,
+              "filterGroups": null,
+              "defaultSort": null,
+              "cursor": "",
+              "page": 1,
+              "limit": 5,
+              "hasNext": false,
+              "parentName": null,
+              "name": "dashboard",
+              "reportPeriod": null,
+              "binds": null,
+              "refresh": false
+            }
+          ]
+        },
+        "navigation": {
+          "menu": [
+            {
+              "id": "c0834fe7041a4442b1028a75ca8e71ed",
+              "hidden": false,
+              "title": "Dashboard",
+              "child": [
+                {
+                  "id": "a2630174a5c744c5a82b63c49a036c2b",
+                  "hidden": false,
+                  "viewName": "dashboard"
+                },
+                {
+                  "id": "46820c2a3931468fa1d77c2f67384434",
+                  "hidden": false,
+                  "viewName": "dashboardoutlet"
+                }
+              ]
+            }
+          ]
+        },
+        "primaries": [
+          "dashboard"
+        ]
+      }
+    },
+    {
+      "id": "id2",
+      "name": "task",
+      "text": "My Tasks",
+      "url": "/screen/task",
+      "icon": "file-add",
+      "defaultScreen": false,
+      "meta": {
+        "id": "1289817",
+        "errors": null,
+        "vstamp": 0,
+        "name": "task",
+        "title": "My Tasks",
+        "primary": "senttasklist",
+        "views": [
+          {
+            "id": 1290921,
+            "name": "senttasklist",
+            "template": "DashboardView",
+            "title": "Sent Tasks",
+            "url": "/screen/task/view/senttasklist",
+            "customizable": false,
+            "editable": false,
+            "widgets": [
+              {
+                "id": "1290259",
+                "errors": null,
+                "vstamp": 0,
+                "name": "sentTaskListHeader",
+                "widgetId": 0,
+                "position": 1,
+                "descriptionTitle": null,
+                "description": null,
+                "snippet": null,
+                "showExportStamp": false,
+                "limit": 0,
+                "type": "Header",
+                "url": null,
+                "bcName": null,
+                "title": "Sent Tasks",
+                "fields": [],
+                "options": {},
+                "pivotFields": null,
+                "axisFields": [],
+                "showCondition": [],
+                "chart": [],
+                "graph": null,
+                "x": null,
+                "y": null,
+                "width": null,
+                "height": null,
+                "minHeight": null,
+                "maxHeight": null,
+                "minWidth": null,
+                "maxWidth": null,
+                "isDraggable": null,
+                "isResizable": null,
+                "gridWidth": 4,
+                "gridBreak": 0,
+                "hide": false
+              }
+            ],
+            "columns": null,
+            "rowHeight": null,
+            "readOnly": false,
+            "ignoreHistory": false,
+            "options": []
+          },
+          {
+            "id": 1290920,
+            "name": "receivedtasklist",
+            "template": "DashboardView",
+            "title": "Received Tasks",
+            "url": "/screen/task/view/receivedtasklist",
+            "customizable": false,
+            "editable": false,
+            "widgets": [
+              {
+                "id": "1290248",
+                "errors": null,
+                "vstamp": 0,
+                "name": "receivingTaskListHeader",
+                "widgetId": 0,
+                "position": 1,
+                "descriptionTitle": null,
+                "description": null,
+                "snippet": null,
+                "showExportStamp": false,
+                "limit": 0,
+                "type": "Header",
+                "url": null,
+                "bcName": null,
+                "title": "Received Tasks",
+                "fields": [],
+                "options": {},
+                "pivotFields": null,
+                "axisFields": [],
+                "showCondition": [],
+                "chart": [],
+                "graph": null,
+                "x": null,
+                "y": null,
+                "width": null,
+                "height": null,
+                "minHeight": null,
+                "maxHeight": null,
+                "minWidth": null,
+                "maxWidth": null,
+                "isDraggable": null,
+                "isResizable": null,
+                "gridWidth": 4,
+                "gridBreak": 0,
+                "hide": false
+              }
+            ],
+            "columns": null,
+            "rowHeight": null,
+            "readOnly": false,
+            "ignoreHistory": false,
+            "options": []
+          }
+        ],
+        "bo": {
+          "bc": [
+            {
+              "id": null,
+              "url": "massOperationApproversListPopup",
+              "defaultFilter": null,
+              "dimFilterSpec": null,
+              "filterGroups": null,
+              "defaultSort": null,
+              "cursor": "",
+              "page": 1,
+              "limit": 5,
+              "hasNext": false,
+              "parentName": null,
+              "name": "massOperationApproversListPopup",
+              "reportPeriod": null,
+              "binds": null,
+              "refresh": false
+            }
+          ]
+        },
+        "navigation": {
+          "menu": [
+            {
+              "id": "678c04cdd40d463b9921cce802ea1c1f",
+              "hidden": false,
+              "viewName": "senttasklist"
+            },
+            {
+              "id": "4999ef42571140008efc3b9a51bae01e",
+              "hidden": false,
+              "viewName": "receivedtasklist"
+            }
+          ]
+        },
+        "primaries": [
+          "senttasklist"
+        ]
+      }
+    }
+  ],
+  "userSettingsVersion": null,
+  "featureSettings": [
+    {
+      "type": null,
+      "key": "FEATURE_FULL_STACKTRACES",
+      "value": "true",
+      "description": null,
+      "language": null,
+      "displayOrder": null,
+      "active": true,
+      "cacheLoaderName": null
+    }
+  ],
+  "systemUrl": null,
+  "timezone": "Asia/Aden",
+  "language": "en"
+}

--- a/src/epics/session/__tests__/loginByAnotherRoleEpic.test.ts
+++ b/src/epics/session/__tests__/loginByAnotherRoleEpic.test.ts
@@ -1,0 +1,152 @@
+/*
+ * TESLER-UI
+ * Copyright (C) 2018-2020 Tesler Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Store } from 'redux'
+import { Store as CoreStore } from '../../../interfaces/store'
+import { mockStore } from '../../../tests/mockStore'
+import { loginByRoleRequest } from '../../../api'
+import { Observable } from 'rxjs'
+import * as api from '../../../api/api'
+import { $do } from '../../../actions/actions'
+import { loginByAnotherRoleEpic } from '../loginByAnotherRole'
+import { ActionsObservable } from 'redux-observable'
+import { testEpic } from '../../../tests/testEpic'
+import * as router from '../../../reducers/router'
+import * as response from './__mocks__/response.json'
+
+const loginByRoleRequestMock = jest.fn().mockImplementation((...args: Parameters<typeof loginByRoleRequest>) => {
+    const [role] = args
+    switch (role) {
+        case 'Auditor':
+            return Observable.of({ ...response, activeRole: role })
+        case 'Reader':
+            return Observable.of({
+                ...response,
+                activeRole: role,
+                screens: [{ ...response.screens[0], defaultScreen: true }, { ...response.screens[1] }]
+            })
+        case 'error': {
+            return Observable.of(jest.fn().mockImplementationOnce(() => Promise.reject(new Error('test request crash'))))
+        }
+        default:
+            return Observable.of(response)
+    }
+})
+const consoleMock = jest.fn().mockImplementation(e => console.warn(e))
+const historyObjMock = jest.fn()
+jest.spyOn<any, any>(api, 'loginByRoleRequest').mockImplementation(loginByRoleRequestMock)
+jest.spyOn(console, 'error').mockImplementation(consoleMock)
+jest.spyOn(router, 'changeLocation').mockImplementation(historyObjMock)
+describe('loginByAnotherRoleEpic test', () => {
+    let store: Store<CoreStore> = null
+
+    beforeAll(() => {
+        store = mockStore()
+    })
+    beforeEach(() => {
+        store.getState().session = {
+            ...store.getState().session,
+            activeRole: 'ADMIN',
+            roles: [
+                {
+                    type: null,
+                    key: 'Auditor',
+                    value: 'Auditor',
+                    description: null,
+                    language: null,
+                    displayOrder: null,
+                    active: true,
+                    cacheLoaderName: null
+                },
+                {
+                    type: null,
+                    key: 'Reader',
+                    value: 'Reader',
+                    description: null,
+                    language: null,
+                    displayOrder: null,
+                    active: true,
+                    cacheLoaderName: null
+                },
+                {
+                    type: null,
+                    key: 'ADMIN',
+                    value: 'Administrator',
+                    description: null,
+                    language: null,
+                    displayOrder: null,
+                    active: true,
+                    cacheLoaderName: null
+                }
+            ]
+        }
+    })
+    afterAll(() => {
+        loginByRoleRequestMock.mockRestore()
+        consoleMock.mockRestore()
+        historyObjMock.mockRestore()
+    })
+    it('should skip login without role', () => {
+        const action = $do.login({ login: 'sss', password: 'sss' })
+        const epic = loginByAnotherRoleEpic(ActionsObservable.of(action), store)
+        testEpic(epic, result => {
+            expect(result.length).toBe(0)
+        })
+    })
+    it('should login without role switching', () => {
+        const role = store.getState().session.activeRole
+        const action = $do.login({ login: null, password: null, role })
+        const epic = loginByAnotherRoleEpic(ActionsObservable.of(action), store)
+        testEpic(epic, result => {
+            expect(historyObjMock).toHaveBeenCalledTimes(0)
+            expect(result.length).toBe(1)
+            expect(result[0].payload.activeRole).toBe(role)
+            expect(loginByRoleRequestMock).toHaveBeenCalledWith(role)
+        })
+    })
+    it('should login with role switching', () => {
+        const role = store.getState().session.roles[0].key
+        const action = $do.login({ login: null, password: null, role })
+        const epic = loginByAnotherRoleEpic(ActionsObservable.of(action), store)
+        testEpic(epic, result => {
+            expect(historyObjMock).toHaveBeenCalled()
+            expect(result.length).toBe(1)
+            expect(result[0].payload.activeRole).toBe(role)
+            expect(loginByRoleRequestMock).toHaveBeenCalledWith(role)
+        })
+    })
+    it('should login with role switching (branch with default screen)', () => {
+        const role = store.getState().session.roles[1].key
+        const action = $do.login({ login: null, password: null, role })
+        const epic = loginByAnotherRoleEpic(ActionsObservable.of(action), store)
+        testEpic(epic, result => {
+            expect(historyObjMock).toHaveBeenCalled()
+            expect(result.length).toBe(1)
+            expect(result[0].payload.activeRole).toBe(role)
+            expect(loginByRoleRequestMock).toHaveBeenCalledWith(role)
+        })
+    })
+    it('should handle error', () => {
+        const action = $do.login({ login: null, password: null, role: 'error' })
+        const epic = loginByAnotherRoleEpic(ActionsObservable.of(action), store)
+        testEpic(epic, result => {
+            expect(consoleMock).toHaveBeenCalled()
+            expect(result.length).toBe(1)
+            expect(result[0]).toEqual(expect.objectContaining($do.loginFail({ errorMsg: 'Empty server response' })))
+        })
+    })
+})

--- a/src/epics/session/__tests__/loginDone.test.ts
+++ b/src/epics/session/__tests__/loginDone.test.ts
@@ -16,12 +16,12 @@
  */
 
 import { Store } from 'redux'
-import { Store as CoreStore } from '../../interfaces/store'
-import { mockStore } from '../../tests/mockStore'
-import { loginEpic } from './loginDone'
-import { $do } from '../../actions/actions'
+import { Store as CoreStore } from '../../../interfaces/store'
+import { mockStore } from '../../../tests/mockStore'
+import { loginEpic } from '../loginDone'
+import { $do } from '../../../actions/actions'
 import { ActionsObservable } from 'redux-observable'
-import { testEpic } from '../../tests/testEpic'
+import { testEpic } from '../../../tests/testEpic'
 
 describe('`loginDone` epic', () => {
     let store: Store<CoreStore> = null

--- a/src/epics/session/__tests__/refreshMeta.test.ts
+++ b/src/epics/session/__tests__/refreshMeta.test.ts
@@ -1,0 +1,38 @@
+import { Store } from 'redux'
+import { Store as CoreStore } from '../../../interfaces/store'
+import { mockStore } from '../../../tests/mockStore'
+import { $do } from '../../../actions/actions'
+import { ActionsObservable } from 'redux-observable'
+import { refreshMetaEpic } from '../refreshMeta'
+import { testEpic } from '../../../tests/testEpic'
+import { refreshMeta } from '../../../api'
+import * as api from '../../../api/api'
+import { Observable } from 'rxjs/Observable'
+
+const res = {}
+const refreshMetaMock = jest.fn().mockImplementation((...args: Parameters<typeof refreshMeta>) => {
+    return Observable.of(res)
+})
+jest.spyOn<any, any>(api, 'refreshMeta').mockImplementation(refreshMetaMock)
+
+describe('refreshMeta', () => {
+    let store: Store<CoreStore> = null
+
+    beforeAll(() => {
+        store = mockStore()
+    })
+
+    afterAll(() => {
+        refreshMetaMock.mockRestore()
+    })
+    it('should call logoutDone, login, changeLocation', () => {
+        const action = $do.refreshMeta(null)
+        const epic = refreshMetaEpic(ActionsObservable.of(action), store)
+        testEpic(epic, result => {
+            expect(result.length).toBe(3)
+            expect(result[0]).toEqual(expect.objectContaining({ type: 'logoutDone' }))
+            expect(result[1]).toEqual(expect.objectContaining({ type: 'login' }))
+            expect(result[2]).toEqual(expect.objectContaining({ type: 'changeLocation' }))
+        })
+    })
+})

--- a/src/epics/session/__tests__/switchRole.test.ts
+++ b/src/epics/session/__tests__/switchRole.test.ts
@@ -1,0 +1,24 @@
+import { Store } from 'redux'
+import { Store as CoreStore } from '../../../interfaces/store'
+import { mockStore } from '../../../tests/mockStore'
+import { $do, types } from '../../../actions/actions'
+import { ActionsObservable } from 'redux-observable'
+import { switchRoleEpic } from '../switchRole'
+import { testEpic } from '../../../tests/testEpic'
+
+describe('switchRoleEpic', () => {
+    let store: Store<CoreStore> = null
+
+    beforeAll(() => {
+        store = mockStore()
+    })
+    it('should call logoutDone and login', () => {
+        const action = $do.switchRole({ role: 'role' })
+        const epic = switchRoleEpic(ActionsObservable.of(action), store)
+        testEpic(epic, result => {
+            expect(result.length).toBe(2)
+            expect(result[0].type).toBe(types.logoutDone)
+            expect(result[1]).toEqual(expect.objectContaining($do.login({ login: null, password: null, role: 'role' })))
+        })
+    })
+})

--- a/src/epics/session/loginByAnotherRole.ts
+++ b/src/epics/session/loginByAnotherRole.ts
@@ -1,0 +1,89 @@
+/*
+ * TESLER-UI
+ * Copyright (C) 2018-2020 Tesler Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { $do, ActionsMap, AnyAction, Epic, types } from '../../actions/actions'
+import { Store } from 'redux'
+import { Store as CoreStore } from '../../interfaces/store'
+import { loginByRoleRequest } from '../../api'
+import { LoginResponse } from '../../interfaces/session'
+import { changeLocation } from '../../reducers/router'
+import { Observable } from 'rxjs'
+import { AxiosError } from 'axios'
+import i18n from 'i18next'
+
+const responseStatusMessages: Record<number, string> = {
+    401: i18n.t('Invalid credentials'),
+    403: i18n.t('Access denied')
+}
+
+/**
+ * Performed on role switching
+ *
+ * @param action$ This epic will fire on {@link ActionPayloadTypes.login | login} action
+ * @param store Redux store instance
+ * @category Epics
+ */
+export const loginByAnotherRoleEpic: Epic = (action$, store) =>
+    action$
+        .ofType(types.login)
+        .filter(action => !!action.payload?.role)
+        .switchMap(action => {
+            return loginByAnotherRoleEpicImpl(action, store)
+        })
+
+/**
+ * Default implementation of `loginByAnotherRoleEpic` epic
+ *
+ * Performs login request with `role` parameter
+ *
+ * If `role` changed, epic changes location to default view
+ *
+ * @param action action {@link ActionPayloadTypes.login | login}
+ * @param store Store instance
+ * @category Epics
+ */
+export function loginByAnotherRoleEpicImpl(action: ActionsMap['login'], store: Store<CoreStore, AnyAction>) {
+    const { role } = action.payload
+    const isSwitchRole = role && role !== store.getState().session.activeRole
+    return loginByRoleRequest(role)
+        .mergeMap((data: LoginResponse) => {
+            if (isSwitchRole) {
+                const defaultScreen = data.screens.find(screen => screen.defaultScreen) || data.screens[0]
+                const defaultViewName = defaultScreen?.primary ?? defaultScreen.meta.views[0].name
+                const defaultView = defaultScreen?.meta.views.find(view => defaultViewName === view.name)
+                if (defaultView) changeLocation(defaultView.url)
+            }
+            return Observable.of(
+                $do.loginDone({
+                    devPanelEnabled: data.devPanelEnabled,
+                    activeRole: data.activeRole,
+                    roles: data.roles,
+                    screens: data.screens,
+                    firstName: data.firstName,
+                    lastName: data.lastName,
+                    login: data.login
+                })
+            )
+        })
+        .catch((error: AxiosError) => {
+            console.error(error)
+            const errorMsg = error.response
+                ? responseStatusMessages[error.response.status] || 'Server application unavailable'
+                : 'Empty server response'
+            return Observable.of($do.loginFail({ errorMsg }))
+        })
+}

--- a/src/epics/session/refreshMeta.ts
+++ b/src/epics/session/refreshMeta.ts
@@ -1,0 +1,44 @@
+/*
+ * TESLER-UI
+ * Copyright (C) 2018-2020 Tesler Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { $do, Epic, types } from '../../actions/actions'
+import { Observable } from 'rxjs/Observable'
+import { refreshMeta } from '../../api'
+
+/**
+ * Performed on refresh meta data process.
+ *
+ * @param action$ This epic will fire on {@link ActionPayloadTypes.refreshMeta | refreshMeta} action
+ * @param store Redux store instance
+ * @category Epics
+ */
+export const refreshMetaEpic: Epic = (action$, store): Observable<any> =>
+    action$.ofType(types.refreshMeta).mergeMap(() => {
+        const state = store.getState()
+        const { router } = state
+        const { activeRole } = state.session
+        return refreshMeta().switchMap(() => {
+            return Observable.concat([
+                $do.logoutDone(null),
+                $do.login({ login: null, password: null, role: activeRole }),
+                $do.changeLocation({
+                    location: router,
+                    action: 'PUSH'
+                })
+            ]).catch(error => Observable.of($do.loginFail(error)))
+        })
+    })

--- a/src/epics/session/switchRole.ts
+++ b/src/epics/session/switchRole.ts
@@ -15,18 +15,17 @@
  * limitations under the License.
  */
 
+import { $do, Epic, types } from '../../actions/actions'
 import { Observable } from 'rxjs'
-import { Epic, types } from '../../actions/actions'
 
 /**
- * Fires on successful login; there is no default implementation related to this epic,
- * but it can be used to customize successful login behaivior.
+ * Activates process of role switching
  *
- * @param action$ This epic will fire on {@link ActionPayloadTypes.login | login} action
+ * @param action$ This epic will fire on {@link ActionPayloadTypes.switchRole | switchRole} action
  * @param store Redux store instance
  * @category Epics
  */
-export const loginEpic: Epic = (action$, store) =>
-    action$.ofType(types.login).switchMap(action => {
-        return Observable.empty()
+export const switchRoleEpic: Epic = (action$, store) =>
+    action$.ofType(types.switchRole).switchMap(action => {
+        return Observable.concat([$do.logoutDone(null), $do.login({ login: null, password: null, role: action.payload.role })])
     })

--- a/src/interfaces/session.ts
+++ b/src/interfaces/session.ts
@@ -1,12 +1,36 @@
 import { ScreenMetaResponse } from './screen'
 import { TeslerResponse } from './objectMap'
 
+export interface UserRole {
+    type: string
+    key: string
+    value: string
+    description: string
+    language: string
+    displayOrder: number
+    active: boolean
+    cacheLoaderName: string
+}
+
 export interface Session {
+    /**
+     * Whether dev tools panel is shown
+     */
+    devPanelEnabled?: boolean
+    activeRole?: string
+    roles?: UserRole[]
+    /**
+     * Shows if debug mode is enabled
+     */
+    debugMode?: boolean
     /**
      * Enables availability of saving redux store and other info on user device.
      * There is need to set it to `true` from client application.
      */
     exportStateEnabled?: boolean
+    firstName?: string
+    lastName?: string
+    login?: string
     active: boolean
     screens: SessionScreen[]
     loginSpin: boolean
@@ -14,6 +38,12 @@ export interface Session {
 }
 
 export interface LoginResponse extends TeslerResponse {
+    devPanelEnabled?: boolean
+    activeRole?: string
+    roles?: UserRole[]
+    firstName?: string
+    lastName?: string
+    login?: string
     screens: SessionScreen[]
     // TODO: Сравнить ответы досье и УОР
 }
@@ -23,6 +53,7 @@ export interface SessionScreen {
     name: string
     text: string // Отображаемое название
     url: string
+    primary?: string
     defaultScreen?: boolean
     meta?: ScreenMetaResponse
     icon?: string

--- a/src/reducers/__tests__/session.test.ts
+++ b/src/reducers/__tests__/session.test.ts
@@ -17,6 +17,7 @@
 
 import { $do } from '../../actions/actions'
 import { session, initialState } from '../session'
+import { SessionScreen } from '../../interfaces/session'
 
 describe('session reducer', () => {
     it('sets login spinner and clears session error message on `login` action', () => {
@@ -29,13 +30,19 @@ describe('session reducer', () => {
 
     it('sets session active, clears login spinner and sets screens available for the session on `loginDone` action', () => {
         const state = { ...initialState, loginSpin: true }
-        const screens = [{ id: '1', name: '1', text: '1', url: '1' }]
+        const screens: SessionScreen[] = [{ id: '1', name: '1', text: '1', url: '1', primary: '' }]
         expect(state.active).toBe(false)
-        let nextState = session(state, $do.loginDone({ screens }))
+        let nextState = session(
+            state,
+            $do.loginDone({ screens, activeRole: null, firstName: null, lastName: null, login: null, roles: null })
+        )
         expect(nextState.loginSpin).toBe(false)
         expect(nextState.active).toBe(true)
         expect(nextState.screens).toEqual(screens)
-        nextState = session(state, $do.loginDone({ screens: null }))
+        nextState = session(
+            state,
+            $do.loginDone({ screens: null, activeRole: null, firstName: null, lastName: null, login: null, roles: null })
+        )
         expect(nextState.screens.length).toBe(0)
     })
 
@@ -45,5 +52,11 @@ describe('session reducer', () => {
         const nextState = session(state, $do.loginFail({ errorMsg: 'Your password expired' }))
         expect(nextState.loginSpin).toBe(false)
         expect(nextState.errorMsg).toBe('Your password expired')
+    })
+
+    it('should switch Debug Mode', () => {
+        const state = { ...initialState }
+        const nextState = session(state, $do.switchDebugMode(true))
+        expect(nextState.debugMode).toBe(true)
     })
 })

--- a/src/reducers/session.ts
+++ b/src/reducers/session.ts
@@ -19,6 +19,13 @@ import { AnyAction, types } from '../actions/actions'
 import { Session } from '../interfaces/session'
 
 export const initialState: Session = {
+    devPanelEnabled: false,
+    activeRole: null,
+    roles: null,
+    firstName: '',
+    lastName: '',
+    login: '',
+    debugMode: false,
     exportStateEnabled: false,
     active: false,
     loginSpin: false,
@@ -42,10 +49,25 @@ export function session(state = initialState, action: AnyAction): Session {
             return { ...state, loginSpin: true, errorMsg: null }
         }
         case types.loginDone: {
-            return { ...state, loginSpin: false, active: true, screens: action.payload.screens || [] }
+            const loginResponse = action.payload
+            return {
+                ...state,
+                devPanelEnabled: loginResponse.devPanelEnabled,
+                activeRole: loginResponse.activeRole,
+                roles: loginResponse.roles,
+                firstName: loginResponse.firstName,
+                lastName: loginResponse.lastName,
+                login: loginResponse.login,
+                loginSpin: false,
+                active: true,
+                screens: loginResponse.screens || []
+            }
         }
         case types.loginFail: {
             return { ...state, loginSpin: false, errorMsg: action.payload.errorMsg }
+        }
+        case types.switchDebugMode: {
+            return { ...state, debugMode: action.payload }
         }
         default:
             return state

--- a/src/utils/__tests__/configureStore.test.ts
+++ b/src/utils/__tests__/configureStore.test.ts
@@ -1,16 +1,25 @@
 import { $do, types } from '../../actions/actions'
 import { configureStore } from '../configureStore'
 import * as router from '../../Provider'
+import { LoginResponse } from '../../interfaces/session'
 
 jest.spyOn(router, 'parseLocation').mockImplementation(() => {
     return { screenName: null, viewName: null, type: null, path: null, params: null }
 })
 
+const loginResponce: LoginResponse = {
+    screens: null,
+    activeRole: null,
+    roles: null,
+    firstName: null,
+    lastName: null,
+    login: null
+}
 describe('configureStore', () => {
     it('handles built-in actions by built-in reducers', () => {
         const store = configureStore({}, null, false, null)
         expect(store.getState().session.active).toBe(false)
-        store.dispatch($do.loginDone({ screens: null }))
+        store.dispatch($do.loginDone(loginResponce))
         expect(store.getState().session.active).toBe(true)
     })
 
@@ -34,7 +43,7 @@ describe('configureStore', () => {
             null
         )
         expect(storeInstance.getState().session.active).toBe(false)
-        storeInstance.dispatch($do.loginDone({ screens: null }))
+        storeInstance.dispatch($do.loginDone(loginResponce))
         expect(storeInstance.getState().session.active).toBe(true)
         expect(mock).toBeCalledWith('success')
     })
@@ -59,7 +68,7 @@ describe('configureStore', () => {
             null
         )
         expect(storeInstance.getState().session.active).toBe(false)
-        storeInstance.dispatch($do.loginDone({ screens: null }))
+        storeInstance.dispatch($do.loginDone(loginResponce))
         expect(storeInstance.getState().session.active).toBe(false)
         expect(mock).toBeCalledWith('success')
     })
@@ -82,7 +91,7 @@ describe('configureStore', () => {
             null
         )
         expect(storeInstance.getState().customSlice).toBe(0)
-        storeInstance.dispatch($do.loginDone({ screens: null }))
+        storeInstance.dispatch($do.loginDone(loginResponce))
         expect(storeInstance.getState().customSlice).toBe(1)
     })
 })

--- a/src/utils/highlightJson.ts
+++ b/src/utils/highlightJson.ts
@@ -1,0 +1,70 @@
+const defaultColors = {
+    keyColor: 'dimgray',
+    numberColor: 'lightskyblue',
+    stringColor: 'lightcoral',
+    trueColor: 'lightseagreen',
+    falseColor: '#f66578',
+    nullColor: 'cornflowerblue'
+}
+
+const entityMap = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+    '`': '&#x60;',
+    '=': '&#x3D;'
+}
+
+function escapeHtml(html: any) {
+    return String(html).replace(/[&<>"'`=]/g, function (s) {
+        return entityMap[s as keyof typeof entityMap]
+    })
+}
+
+/**
+ * Format json and highlight it as well.
+ * May not be suitable for handling huge (such as 10MB) JSON.
+ *
+ * It's temp solution
+ *
+ * @param json JSON to highlight
+ * @param colorOptions optional color options
+ * @category Utils
+ */
+function highlightJson(json: any, colorOptions = {}) {
+    const valueType = typeof json
+    if (valueType !== 'string') {
+        json = JSON.stringify(json, null, 2) || valueType
+    }
+    const colors = Object.assign({}, defaultColors, colorOptions)
+    json = json.replace(/&/g, '&').replace(/</g, '<').replace(/>/g, '>')
+    return json.replace(
+        /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+]?\d+)?)/g,
+        (match: any) => {
+            let color = colors.numberColor
+            let style = ''
+            if (/^"/.test(match)) {
+                if (/:$/.test(match)) {
+                    color = colors.keyColor
+                } else {
+                    color = colors.stringColor
+                    match = '"' + escapeHtml(match.substr(1, match.length - 2)) + '"'
+                    style = 'word-wrap:break-word;white-space:pre-wrap;'
+                }
+            } else {
+                color = /true/.test(match)
+                    ? colors.trueColor
+                    : /false/.test(match)
+                    ? colors.falseColor
+                    : /null/.test(match)
+                    ? colors.nullColor
+                    : color
+            }
+            return `<span style="${style}color:${color}">${match}</span>`
+        }
+    )
+}
+
+export default highlightJson


### PR DESCRIPTION
See #609

This PR add the following features:

1. **`debugMode`**. It's just flag in `State > session > debugMode`.
If `debugMode` is true, then info about widget meta data, BC and business data is showed neat its widget, and names of screen and view are shown on the top of view. See [DebugPanel](https://github.com/tesler-platform/tesler-ui/pull/610/files#diff-866a224ea6ee3ac7f9fd2c2497da85f4663b39e7fef91a5cbd0279edf9c0087fR13) with its components and [ViewInfoLabel](https://github.com/tesler-platform/tesler-ui/pull/610/files#diff-07c138a5dccf8882cfe38fa781a42284c36298678f4d8f6974e37e0609af585eR7) component.
2. **Dev tools panel**. See [DevToolsPanel](https://github.com/tesler-platform/tesler-ui/pull/610/files#diff-46b99d0905900496d7dc4cec8b116cab547f3a691413ee927017cfcbbdf211b8R16)
It's [exported](https://github.com/tesler-platform/tesler-ui/pull/610/files#diff-7fd43b0b162a214d655a8176a345b983bfa23ff95be8e4059e587cf9db3fc51fR43) so could be used in client project.
The first button sends api request to [bc-registry/refresh-meta](https://github.com/tesler-platform/tesler-ui/pull/610/files#diff-ba54f2f51eac8ba66d9ea37ae9d3c13bbd71cf8c54d9cd898318e6267b0e6542R207) and makes [relogin](https://github.com/tesler-platform/tesler-ui/pull/610/files#diff-00633e486d7013497dedf4e9828dc77868199b170e5b05ddd971abd9124a8dd4R34) with new meta data.
The second button enables/disables `debugMode`.
3. **Role swithing process**. It's required by dev tool panel.
It triggers by `login` action with `role` parameter. See [loginByAnotherRoleEpic](https://github.com/tesler-platform/tesler-ui/pull/610/files#diff-6e832d438ce251ea67c40ecf16a481f774102d6e610658c59e278371257d2d90R40)