### PR TITLE
`<MultivalueHover />` should not show arrow icon when no drilldown handler available

### DIFF
--- a/src/components/ui/Multivalue/MultivalueHover.tsx
+++ b/src/components/ui/Multivalue/MultivalueHover.tsx
@@ -36,9 +36,9 @@ const Multivalue: React.FunctionComponent<MultivalueHoverProps> = props => {
                     props.displayedValue
                 )}
             </p>
-        ) : (
+        ) : props.onDrillDown ? (
             <Icon className={cn(props.className)} type="left-circle" onClick={props.onDrillDown} />
-        )
+        ) : null
     const fields = props.data.map((multivalueSingleValue, index) => {
         return (
             <div className={styles.multivalueFieldArea} key={index}>


### PR DESCRIPTION
It's hard to tell if such thing as "arrow icon" is needed here at all, as originally it came with matching icon in true branch; possibly some garbage code.

While investigating though what we can definetly do is to disable this thing when no drilldown callback provided in props, meaning this icon is completely useless.