### PR TITLE
`bcNewDataSuccess` resets selectedCell;  `operationRequiresAutosave` of `requiredFields` middleware ignores save operation (#612)

### DIFF
--- a/src/reducers/__tests__/view.test.ts
+++ b/src/reducers/__tests__/view.test.ts
@@ -1,0 +1,203 @@
+import view, { initialState } from '../view'
+import { $do } from '../../actions/actions'
+import { OperationTypeCrud } from '@tesler-ui/schema'
+import { RowMeta } from '../../interfaces/rowMeta'
+
+describe('view reducer test', () => {
+    it('should react on action selectView', () => {
+        const nextState = view(
+            initialState,
+            $do.selectView({
+                url: 'url',
+                name: 'name',
+                widgets: []
+            }),
+            null
+        )
+        expect(nextState.url).toBe('url')
+    })
+
+    it('should react on action bcFetchRowMeta', () => {
+        const nextState = view(
+            initialState,
+            $do.bcFetchRowMeta({
+                bcName: 'bcName',
+                widgetName: 'widgetName'
+            }),
+            null
+        )
+        expect(nextState.metaInProgress['bcName']).toBeTruthy()
+    })
+    it('should react on action bcLoadMore', () => {
+        const nextState = view(initialState, $do.bcLoadMore({ bcName: 'bcName', widgetName: 'widgetName' }), null)
+        expect(nextState.infiniteWidgets).toStrictEqual(['widgetName'])
+    })
+    it('should react on action sendOperation save', () => {
+        const nextState = view(
+            initialState,
+            $do.sendOperation({ operationType: OperationTypeCrud.save, widgetName: 'w', bcName: 'bcName' }),
+            null
+        )
+        expect(nextState).toStrictEqual(initialState)
+    })
+    it('should react on action sendOperation create', () => {
+        const nextState = view(
+            initialState,
+            $do.sendOperation({ operationType: OperationTypeCrud.create, widgetName: 'w', bcName: 'bcName' }),
+            null
+        )
+        expect(nextState.metaInProgress['bcName']).toBeTruthy()
+    })
+    it('should react on action bcFetchRowMetaSuccess', () => {
+        const rowMeta: RowMeta = {
+            actions: [],
+            fields: []
+        }
+        const nextState = view(initialState, $do.bcFetchRowMetaSuccess({ bcName: 'bcName', bcUrl: 'url', rowMeta: rowMeta }), null)
+
+        expect(nextState.metaInProgress['bcName']).toBeFalsy()
+        expect(nextState.rowMeta['bcName']).toStrictEqual({ url: rowMeta })
+    })
+
+    it('should clear selectedCell after creating new record', () => {
+        const state = {
+            ...initialState,
+            selectedCell: {
+                widgetName: 'some value',
+                rowId: 'some value',
+                fieldKey: 'some value'
+            }
+        }
+        const nextState = view(
+            state,
+            $do.bcNewDataSuccess({
+                bcName: 'bcNAme',
+                dataItem: { id: '1', vstamp: -1 },
+                bcUrl: 'bcUrl'
+            }),
+            null
+        )
+        expect(nextState.selectedCell).toBe(initialState.selectedCell)
+    })
+
+    it('should react on action bcNewDataFail', () => {
+        const nextState = view(initialState, $do.bcNewDataFail({ bcName: 'bcName' }), null)
+        expect(nextState.metaInProgress['bcName']).toBeFalsy()
+    })
+
+    it('should react on action bcFetchRowMetaFail', () => {
+        const nextState = view(initialState, $do.bcFetchRowMetaFail({ bcName: 'bcName' }), null)
+        expect(nextState.metaInProgress['bcName']).toBeFalsy()
+    })
+
+    it('should react on action forceActiveChangeFail', () => {
+        const nextState = view(
+            {
+                ...initialState,
+                rowMeta: {
+                    bcName: {
+                        url: null
+                    }
+                }
+            },
+            $do.forceActiveChangeFail({
+                bcName: 'bcName',
+                bcUrl: 'url',
+                viewError: 'error',
+                entityError: { bcName: 'bcName', id: 'id', fields: { a: 'a' } }
+            }),
+            null
+        )
+        expect(nextState.rowMeta['bcName']['url']).toStrictEqual({
+            errors: {
+                a: 'a'
+            }
+        })
+    })
+    it('should react on action bcSaveDataFail', () => {
+        const nextState = view(
+            {
+                ...initialState,
+                rowMeta: {
+                    bcName: {
+                        url: null
+                    }
+                }
+            },
+            $do.bcSaveDataFail({
+                bcName: 'bcName',
+                bcUrl: 'url',
+                viewError: 'error',
+                entityError: { bcName: 'bcName', id: 'id', fields: { a: 'a' } }
+            }),
+            null
+        )
+        expect(nextState.rowMeta['bcName']['url']).toStrictEqual({
+            errors: {
+                a: 'a'
+            }
+        })
+    })
+    it('should react on action sendOperationFail', () => {
+        const nextState = view(
+            {
+                ...initialState,
+                rowMeta: {
+                    bcName: {
+                        url: null
+                    }
+                }
+            },
+            $do.sendOperationFail({
+                bcName: 'bcName',
+                bcUrl: 'url',
+                viewError: 'error',
+                entityError: { bcName: 'bcName', id: 'id', fields: { a: 'a' } }
+            }),
+            null
+        )
+        expect(nextState.rowMeta['bcName']['url']).toStrictEqual({
+            errors: {
+                a: 'a'
+            }
+        })
+    })
+    it('should react on action forceActiveRmUpdate', () => {
+        const rowMeta: RowMeta = {
+            actions: [],
+            fields: [
+                {
+                    key: 'a',
+                    forceActive: true,
+                    currentValue: 'a'
+                },
+                {
+                    key: 'b',
+                    forceActive: true,
+                    currentValue: 'b'
+                }
+            ]
+        }
+        const nextState = view(
+            {
+                ...initialState,
+                pendingDataChanges: {
+                    bcName: {
+                        '1': {}
+                    }
+                }
+            },
+            $do.forceActiveRmUpdate({
+                bcName: 'bcName',
+                bcUrl: 'url',
+                currentRecordData: { id: '1', vstamp: 1 },
+                rowMeta: rowMeta,
+                cursor: '1'
+            }),
+            null
+        )
+        expect(nextState.rowMeta['bcName']['url']).toStrictEqual(rowMeta)
+        // todo add other checks
+    })
+    // TODO other tests
+})

--- a/src/reducers/view.ts
+++ b/src/reducers/view.ts
@@ -6,7 +6,7 @@ import { OperationTypeCrud } from '../interfaces/operation'
 import { buildBcUrl } from '../utils/strings'
 import i18n from 'i18next'
 
-const initialState: ViewState = {
+export const initialState: ViewState = {
     id: null,
     name: null,
     url: null,
@@ -93,6 +93,12 @@ export function view(state = initialState, action: AnyAction, store: Store): Vie
                     ...state.metaInProgress,
                     [action.payload.bcName]: false
                 }
+            }
+        }
+        case types.bcNewDataSuccess: {
+            return {
+                ...state,
+                selectedCell: initialState.selectedCell
             }
         }
         case types.bcNewDataFail:

--- a/src/utils/__tests__/operations.test.tsx
+++ b/src/utils/__tests__/operations.test.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { flattenOperations, matchOperationRole } from '../operations'
+import { checkOperationRole, flattenOperations, matchOperationRole } from '../operations'
 import { Operation, OperationTypeCrud } from '../../interfaces/operation'
 import { mockStore } from '../../tests/mockStore'
 import { ActionPayloadTypes } from '../../actions/actions'
@@ -132,3 +132,11 @@ const sendOperationCustom: ActionPayloadTypes['sendOperation'] = {
     operationType: custom.type,
     widgetName: 'widget-example'
 }
+
+test('checkOperationRole', () => {
+    expect(checkOperationRole(create, OperationTypeCrud.create)).toBeTruthy()
+    expect(checkOperationRole(custom, 'custom')).toBeTruthy()
+    expect(checkOperationRole(custom, OperationTypeCrud.save)).toBeFalsy()
+    expect(checkOperationRole(unsave, OperationTypeCrud.cancelCreate)).toBeTruthy()
+    expect(checkOperationRole(create, OperationTypeCrud.save)).toBeFalsy()
+})

--- a/src/utils/operations.ts
+++ b/src/utils/operations.ts
@@ -63,3 +63,17 @@ export function matchOperationRole(role: OperationTypeCrud | 'none' | string, pa
     }
     return operation?.actionRole === role
 }
+
+/**
+ * Checks whether operation match to role
+ *
+ * @param operation Operation to check
+ * @param role Expected operation role
+ * @category Utils
+ */
+export function checkOperationRole(operation: Operation, role: OperationTypeCrud | string) {
+    if (operation.type === role) {
+        return true
+    }
+    return operation.actionRole === role
+}


### PR DESCRIPTION
According the description #612 the reason of circular calling actions `sendOperation` with type `save` and `selectTableCellInit` is stale data in `selectedCell`. 

`selectedCell` isn't reseted after successful creating new table and it cheat on `autosaveMiddleware` [here](https://github.com/tesler-platform/tesler-ui/blob/master/src/middlewares/autosaveMiddleware.ts#L42) while processing of action `selectTableCellInit`.

Also `requiredFieldsMiddleware` reacts on `sendOperation` action with type `OperationTypeCrud.save`. This operation has `autoSaveBefore` flag. Since this operation is called on table widget `requiredFieldsMiddleware` calls `selectTableCellInit` action.

Hence we go to close loop.

To brake the loop we need to clear `selectedCell` by `bcNewDataSuccess` action . 
Also `requiredFieldsMiddleware` should ignore `autoSaveBefore` flag on save operation.