### PR TITLE
coverage pipeline run twice on opened pull request

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,11 +1,8 @@
 name: Tests and Coverage
 
 on:
-  push:
-    branches:
-    - 'master'
-    - 'develop'
   pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   build:


### PR DESCRIPTION
Unit tests and coverage workflow fires twice for each commit: once when pull request is opened and results are shown in PR, and once again when PR is merged and workflow results are not used anywhere.  