### PR TITLE
The record is saved with empty required fields

### DIFF
--- a/src/middlewares/__tests__/requiredFieldsMiddleware.test.ts
+++ b/src/middlewares/__tests__/requiredFieldsMiddleware.test.ts
@@ -162,12 +162,12 @@ describe('hasPendingValidationFails old format test', () => {
 })
 
 describe('operationRequiresAutosave', () => {
-    it('should ignore save action', () => {
+    it('should return true on save action', () => {
         expect(
             operationRequiresAutosave(OperationTypeCrud.save, [
                 { type: OperationTypeCrud.save, scope: 'bc', autoSaveBefore: true, text: 'save' }
             ])
-        ).toBeFalsy()
+        ).toBeTruthy()
     })
     it('should ignore save role action', () => {
         expect(

--- a/src/middlewares/requiredFieldsMiddleware.ts
+++ b/src/middlewares/requiredFieldsMiddleware.ts
@@ -12,9 +12,8 @@ import i18n from 'i18next'
 import { DataItem, PendingDataItem } from '../interfaces/data'
 import { RowMetaField } from '../interfaces/rowMeta'
 import { isWidgetFieldBlock, TableLikeWidgetTypes, WidgetField, WidgetFieldBlock, WidgetTableMeta } from '../interfaces/widget'
-import { checkOperationRole, flattenOperations } from '../utils/operations'
+import { flattenOperations } from '../utils/operations'
 import { PendingValidationFailsFormat } from '../interfaces/view'
-import { OperationTypeCrud } from '@tesler-ui/schema'
 
 const requiredFields = ({ getState, dispatch }: MiddlewareAPI<Dispatch<AnyAction>, CoreStore>) => (next: Dispatch) => (
     action: AnyAction
@@ -92,9 +91,7 @@ export function operationRequiresAutosave(operationType: string, actions: Array<
         console.error('rowMeta is missing in the middle of "sendOperation" action')
         return result
     }
-    result = flattenOperations(actions).some(
-        action => action.type === operationType && action.autoSaveBefore && !checkOperationRole(action, OperationTypeCrud.save)
-    )
+    result = flattenOperations(actions).some(action => action.type === operationType && action.autoSaveBefore)
     return result
 }
 

--- a/src/utils/__tests__/operations.test.tsx
+++ b/src/utils/__tests__/operations.test.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { checkOperationRole, flattenOperations, matchOperationRole } from '../operations'
+import { flattenOperations, matchOperationRole } from '../operations'
 import { Operation, OperationTypeCrud } from '../../interfaces/operation'
 import { mockStore } from '../../tests/mockStore'
 import { ActionPayloadTypes } from '../../actions/actions'
@@ -132,11 +132,3 @@ const sendOperationCustom: ActionPayloadTypes['sendOperation'] = {
     operationType: custom.type,
     widgetName: 'widget-example'
 }
-
-test('checkOperationRole', () => {
-    expect(checkOperationRole(create, OperationTypeCrud.create)).toBeTruthy()
-    expect(checkOperationRole(custom, 'custom')).toBeTruthy()
-    expect(checkOperationRole(custom, OperationTypeCrud.save)).toBeFalsy()
-    expect(checkOperationRole(unsave, OperationTypeCrud.cancelCreate)).toBeTruthy()
-    expect(checkOperationRole(create, OperationTypeCrud.save)).toBeFalsy()
-})

--- a/src/utils/operations.ts
+++ b/src/utils/operations.ts
@@ -63,17 +63,3 @@ export function matchOperationRole(role: OperationTypeCrud | 'none' | string, pa
     }
     return operation?.actionRole === role
 }
-
-/**
- * Checks whether operation match to role
- *
- * @param operation Operation to check
- * @param role Expected operation role
- * @category Utils
- */
-export function checkOperationRole(operation: Operation, role: OperationTypeCrud | string) {
-    if (operation.type === role) {
-        return true
-    }
-    return operation.actionRole === role
-}


### PR DESCRIPTION
See #654 

Actually, it's reverting part of #637 which ignoring `autoSaveBefore` flag on save operation in `requiredFieldsMiddleware`.