### PR TITLE
`<ColumnFilter />` fails to open filtration popup for multivalue fields

### DIFF
--- a/src/components/ColumnTitle/ColumnFilter.tsx
+++ b/src/components/ColumnTitle/ColumnFilter.tsx
@@ -60,7 +60,7 @@ export const ColumnFilter: React.FC<ColumnFilterProps> = props => {
     )
 
     const isPickList = props.widgetMeta.type === FieldType.pickList
-    const isMultivalue = props.widgetMeta.type === FieldType.multivalue || isPickList
+    const isMultivalue = [FieldType.multivalue, FieldType.multivalueHover].includes(props.widgetMeta.type) || isPickList
 
     const fieldMeta = props.widget?.fields.find((field: WidgetField) => field.key === props.widgetMeta.key) as
         | MultivalueFieldMeta
@@ -73,7 +73,7 @@ export const ColumnFilter: React.FC<ColumnFilterProps> = props => {
             dispatch(
                 $do.showViewPopup({
                     bcName: fieldMeta.popupBcName,
-                    widgetName: !isPickList ? props.widget?.name : assocWidget.name,
+                    widgetName: assocWidget?.name,
                     calleeBCName: props.widget?.bcName,
                     calleeWidgetName: props.widget?.name,
                     assocValueKey: !isPickList ? fieldMetaMultivalue.assocValueKey : fieldMetaPickListField.pickMap[fieldMeta.key],


### PR DESCRIPTION
Apparently was broken [here](https://github.com/tesler-platform/tesler-ui/pull/621/files#diff-010281f09484714335e1982d158d2eb1424c3f4bffdbe45c051e3b7415f8162dR76) by passing `widgetName` in `showViewPopup` reducer but assigning it with widget's own name for multivalue fields, filters for which reuse same logic as picklists.

Also `multivalueHover` should be considered the same as `multivalue` for the purposes of column filtration