### PR TITLE
Hide elements in AssocListPopup hierarchy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 name: Build
 

--- a/src/components/FullHierarchyTable/FullHierarchyTable.tsx
+++ b/src/components/FullHierarchyTable/FullHierarchyTable.tsx
@@ -146,7 +146,7 @@ export const FullHierarchyTable: React.FunctionComponent<FullHierarchyTableAllPr
     const tableRecords = React.useMemo<ChildrenAwaredHierarchyItem[]>(() => {
         return displayedData
             ?.filter(dataItem => {
-                return dataItem.level === depth && (dataItem.level === 1 || dataItem.parentId === parentId)
+                return dataItem.level === depth && (dataItem.level === 1 || dataItem.parentId === parentId) && !dataItem._hidden
             })
             .map(filteredItem => {
                 return {

--- a/src/components/HierarchyTable/HierarchyTable.tsx
+++ b/src/components/HierarchyTable/HierarchyTable.tsx
@@ -176,12 +176,14 @@ export const HierarchyTable: FunctionComponent<HierarchyTableProps> = ({
     const [currentCursor, setCurrentCursor] = React.useState(undefined)
     const [noChildRecords, setNoChildRecords] = React.useState([])
     const tableRecords = React.useMemo(() => {
-        return data?.map(item => {
-            return {
-                ...item,
-                noChildren: noChildRecords.includes(item.id)
-            }
-        })
+        return data
+            ?.filter(dataItem => !dataItem._hidden)
+            ?.map(item => {
+                return {
+                    ...item,
+                    noChildren: noChildRecords.includes(item.id)
+                }
+            })
     }, [data, noChildRecords])
     const [userClosedRecords, setUserClosedRecords] = React.useState([])
     const expandedRowKeys = React.useMemo(() => {

--- a/src/components/widgets/AssocListPopup/AssocListPopup.tsx
+++ b/src/components/widgets/AssocListPopup/AssocListPopup.tsx
@@ -151,18 +151,19 @@ export const AssocListPopup: FunctionComponent<IAssocListProps & IAssocListActio
 
     // Tag values limit
     const tagLimit = 5
-    const visibleTags = selectedRecords
+    const tagRecords = selectedRecords.filter(item => !item._hidden)
+    const visibleTags = tagRecords
         .map(item => ({
             ...item,
             _value: String(item[assocValueKey] || ''),
             _closable: true
         }))
         .slice(0, tagLimit)
-    const hiddenTagsCount = selectedRecords.length - tagLimit
+    const hiddenTagsCount = tagRecords.length - tagLimit
     const tags: AssociatedItemTag[] =
-        selectedRecords.length > tagLimit
+        tagRecords.length > tagLimit
             ? [...visibleTags, { id: 'control', _associate: false, _value: `... ${hiddenTagsCount}` }]
-            : selectedRecords.map(item => ({ ...item, _value: String(item[assocValueKey] || ''), _closable: true }))
+            : tagRecords.map(item => ({ ...item, _value: String(item[assocValueKey] || ''), _closable: true }))
 
     const defaultTitle = tags.length ? (
         <div>

--- a/src/interfaces/operation.ts
+++ b/src/interfaces/operation.ts
@@ -350,6 +350,7 @@ export type OperationScope = 'bc' | 'record' | 'page' | 'associate'
 
 export interface AssociatedItem extends DataItem {
     _associate: boolean
+    _hidden?: boolean
 }
 
 export interface OperationError {


### PR DESCRIPTION
see #691

**Extension:** Ability to hide records from the user association in `AssocListPopup`.

Records are excluded by setting of `_hidden` flag in the widget data. At the same time, `TAG` is not displayed, and association `_assotiate` remains active.

`MVG` field will also display hidden records and correctly delete their association.

_example data:_
``` js
data: [
	...
	{
 		businessProcess: "test bp",
		id: 1,
		level: 1,
		name: "test bp",
		number: "1",
		parentId: "0",
		vstamp: 2,
		_associate: true,
		_hidden: true,	// dont't show in popup hierarchy and TAG
	}
	...
]
```