### PR TITLE
`ViewNavigationWidget` and `NavigationTabsWidget` are added

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "webpack-rxjs-externals": "1.1.0"
   },
   "dependencies": {
-    "@tesler-ui/schema": "0.3.4",
+    "@tesler-ui/schema": "0.4.0",
     "classnames": "2.2.6",
     "core-js": "3.1.4",
     "diff": "4.0.2",

--- a/src/assets/styles/theme.less
+++ b/src/assets/styles/theme.less
@@ -49,3 +49,20 @@
 
 // ant update fix
 @background-color-active: #eee;
+
+/*light mode*/
+@main-light-mode: #141F35;
+@accent: #3F7BEF;
+@accent20: #3F7BEF33;
+@not-available: #BBC9D9;
+@warning: #FCA546;
+@warning20: #FCA54633;
+
+@error: #EC3F3F;
+@error20: #EC3F3F33;
+
+@success: #008C3E;
+@success: #008C3E33;
+
+/*dark mode*/
+@main-dark-mode: #FFFFFF;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -26,6 +26,7 @@ export { default as SearchHighlight } from './ui/SearchHightlight/SearchHightlig
 export { default as FilterField } from './ui/FilterField/FilterField'
 export { RowOperationsMenu } from './RowOperations/RowOperationsMenu'
 export { default as RowOperationsButton } from './RowOperations/RowOperationsButton'
+export { default as NavigationTabs } from './ui/NavigationTabs/NavigationTabs'
 
 // Containers
 export { default as TemplatedTitle } from './TemplatedTitle/TemplatedTitle'
@@ -34,7 +35,7 @@ export { default as Widget } from './Widget/Widget'
 export { default as Field } from './Field/Field'
 export { default as ModalInvoke } from './ModalInvoke/ModalInvoke'
 export { default as PickListField } from './PickListField/PickListField'
-// Busines-widgets
+// Business-widgets
 export { default as FormWidget } from './widgets/FormWidget/FormWidget'
 export { default as TableWidget } from './widgets/TableWidget/TableWidget'
 export { default as TextWidget } from './widgets/TextWidget/TextWidget'
@@ -42,5 +43,7 @@ export { default as AssocListPopup } from './widgets/AssocListPopup/AssocListPop
 export { default as PickListPopup } from './widgets/PickListPopup/PickListPopup'
 export { default as FlatTree } from './widgets/FlatTree/FlatTree'
 export { default as FlatTreePopup } from './widgets/FlatTree/FlatTreePopup'
+export { default as ViewNavigationWidget } from './widgets/ViewNavigationWidget/ViewNavigationWidget'
+export { default as NavigationTabsWidget } from './widgets/NavigationTabsWidget/NavigationTabsWidget'
 // Developer
 export { default as DevToolsPanel } from './DevToolsPanel/DevToolsPanel'

--- a/src/components/ui/NavigationTabs/NavigationTabs.less
+++ b/src/components/ui/NavigationTabs/NavigationTabs.less
@@ -1,0 +1,20 @@
+@import "../../../assets/styles/theme.less";
+
+.container {
+  overflow: hidden;
+  :global {
+    .ant-tabs-ink-bar {
+      background-color: @accent;
+    }
+    .ant-tabs-bar {
+      border: none;
+    }
+  }
+}
+
+.item {
+  font-size: 14px;
+  line-height: 20px;
+  color: @main-light-mode;
+}
+

--- a/src/components/ui/NavigationTabs/NavigationTabs.test.tsx
+++ b/src/components/ui/NavigationTabs/NavigationTabs.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { Store } from 'redux'
+import { Store as CoreStore } from '../../../interfaces/store'
+import { mockStore } from '../../../tests/mockStore'
+import { mount } from 'enzyme'
+import { Provider } from 'react-redux'
+import NavigationTabs from './NavigationTabs'
+
+describe('NavigationTabs test', () => {
+    let store: Store<CoreStore> = null
+
+    beforeAll(() => {
+        store = mockStore()
+        store.getState().view.name = 'bankcard'
+        store.getState().session.screens = [
+            {
+                id: '0',
+                name: 'screen-example',
+                url: 'd',
+                text: 'dd',
+                meta: {
+                    bo: null,
+                    navigation: {
+                        menu: [
+                            {
+                                viewName: 'banklist'
+                            },
+                            {
+                                viewName: 'bankcard'
+                            }
+                        ]
+                    },
+                    views: []
+                }
+            }
+        ]
+    })
+
+    beforeEach(() => {
+        store.getState().screen.screenName = 'screen-example'
+        store.getState().screen.views = [
+            { name: 'banklist', url: 'view/view-1', title: 'Bank List', widgets: [] },
+            { name: 'bankcard', url: 'view/view-2', widgets: [] }
+        ]
+    })
+    it('should render tabs', () => {
+        const wrapper = mount(
+            <Provider store={store}>
+                <NavigationTabs navigationLevel={1} />
+            </Provider>
+        )
+        expect(wrapper.find('span').findWhere(i => i.props().className === 'item').length).toBe(2)
+    })
+})

--- a/src/components/ui/NavigationTabs/NavigationTabs.tsx
+++ b/src/components/ui/NavigationTabs/NavigationTabs.tsx
@@ -1,0 +1,45 @@
+/*
+ * TESLER-UI
+ * Copyright (C) 2018-2020 Tesler Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react'
+import { Tabs } from 'antd'
+import styles from './NavigationTabs.less'
+import { useViewTabs } from '../../../hooks'
+import { historyObj } from '../../../reducers/router'
+
+interface NavigationTabsProps {
+    navigationLevel: number
+}
+
+function NavigationTabs({ navigationLevel }: NavigationTabsProps) {
+    const tabs = useViewTabs(navigationLevel)
+    const handleChange = (key: string) => {
+        historyObj.push(key)
+    }
+
+    return (
+        <nav className={styles.container}>
+            <Tabs activeKey={tabs?.find(item => item.selected)?.url} tabBarGutter={24} size="large" onChange={handleChange}>
+                {tabs?.map(item => (
+                    <Tabs.TabPane key={item.url} tab={<span className={styles.item}>{item.title}</span>} />
+                ))}
+            </Tabs>
+        </nav>
+    )
+}
+
+export default React.memo(NavigationTabs)

--- a/src/components/widgets/NavigationTabsWidget/NavigationTabsWidget.test.tsx
+++ b/src/components/widgets/NavigationTabsWidget/NavigationTabsWidget.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { NavigationWidgetMeta } from '../../../interfaces/widget'
+import { WidgetTypes } from '@tesler-ui/schema'
+import { shallow } from 'enzyme'
+import NavigationTabsWidget from './NavigationTabsWidget'
+
+describe('NavigationTabsWidget test', () => {
+    const meta: NavigationWidgetMeta = {
+        name: 'NavigationWidgetMeta',
+        title: '',
+        position: 0,
+        gridWidth: 4,
+        bcName: '',
+        type: WidgetTypes.NavigationTabs,
+        fields: [],
+        options: {
+            navigationLevel: 2
+        }
+    }
+
+    it('should render', () => {
+        const wrapper = shallow(<NavigationTabsWidget meta={meta} />)
+        expect(wrapper.find('Memo(NavigationTabs)').findWhere(i => i.props().navigationLevel === 2).length).toBe(1)
+    })
+
+    it('should not render', () => {
+        const noNavigationLvlMeta = { ...meta, options: {} }
+        const wrapper = shallow(<NavigationTabsWidget meta={noNavigationLvlMeta} />)
+        expect(wrapper.find('Memo(NavigationTabs)').length).toBe(0)
+        expect(wrapper.isEmptyRender()).toBeTruthy()
+    })
+})

--- a/src/components/widgets/NavigationTabsWidget/NavigationTabsWidget.tsx
+++ b/src/components/widgets/NavigationTabsWidget/NavigationTabsWidget.tsx
@@ -1,0 +1,36 @@
+/*
+ * TESLER-UI
+ * Copyright (C) 2018-2020 Tesler Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react'
+import NavigationTabs from '../../ui/NavigationTabs/NavigationTabs'
+import { NavigationWidgetMeta } from '../../../interfaces/widget'
+
+export interface NavigationTabsWidgetProps {
+    meta: NavigationWidgetMeta
+}
+
+function NavigationTabsWidget({ meta }: NavigationTabsWidgetProps) {
+    const navigationLevel = meta.options?.navigationLevel
+
+    if (!navigationLevel) {
+        return null
+    }
+
+    return <NavigationTabs navigationLevel={navigationLevel} />
+}
+
+export default React.memo(NavigationTabsWidget)

--- a/src/components/widgets/ViewNavigationWidget/ViewNavigationWidget.test.tsx
+++ b/src/components/widgets/ViewNavigationWidget/ViewNavigationWidget.test.tsx
@@ -1,0 +1,10 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import ViewNavigationWidget from './ViewNavigationWidget'
+
+describe('ViewNavigation testing', () => {
+    it('should render', () => {
+        const wrapper = shallow(<ViewNavigationWidget />)
+        expect(wrapper.find('Memo(NavigationTabs)').length).toBe(1)
+    })
+})

--- a/src/components/widgets/ViewNavigationWidget/ViewNavigationWidget.tsx
+++ b/src/components/widgets/ViewNavigationWidget/ViewNavigationWidget.tsx
@@ -1,0 +1,25 @@
+/*
+ * TESLER-UI
+ * Copyright (C) 2018-2020 Tesler Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react'
+import NavigationTabs from '../../ui/NavigationTabs/NavigationTabs'
+
+function ViewNavigationWidget() {
+    return <NavigationTabs navigationLevel={1} />
+}
+
+export default React.memo(ViewNavigationWidget)

--- a/src/hooks/useViewTabs.ts
+++ b/src/hooks/useViewTabs.ts
@@ -18,7 +18,7 @@ import { useSelector, shallowEqual } from 'react-redux'
 import { Store } from '../interfaces/store'
 import { getViewTabs } from '../utils/viewTabs'
 import { ViewMetaResponse } from '../interfaces/view'
-import { MenuItem, ViewNavigationCategory, NavigationLevel } from '../interfaces/navigation'
+import { MenuItem, ViewNavigationCategory } from '../interfaces/navigation'
 
 interface UseViewTabsState {
     activeView: string
@@ -40,7 +40,7 @@ function mapStateToProps(store: Store): UseViewTabsState {
  * @param depth 1 for top level navigation; 2, 3, 4 for SecondLevelMenu, ThirdLevelMenu and FourthLevelMenu
  * @category Hooks
  */
-export function useViewTabs(depth: NavigationLevel) {
+export function useViewTabs(depth: number) {
     const state: UseViewTabsState = useSelector(mapStateToProps, shallowEqual)
     const items = getViewTabs(state.navigation, depth, state.activeView)
     return items.map(item => {

--- a/src/interfaces/widget.ts
+++ b/src/interfaces/widget.ts
@@ -153,7 +153,7 @@ export interface WidgetTableMeta extends WidgetMeta {
  */
 export interface WidgetInfoMeta extends WidgetMeta {
     /**
-     * Unambiguous marker for JSON file specifing widget type
+     * Unambiguous marker for JSON file specifying widget type
      */
     type: WidgetTypes.Info
     /**
@@ -171,7 +171,7 @@ export interface WidgetInfoMeta extends WidgetMeta {
  */
 export interface WidgetTextMeta extends WidgetMeta {
     /**
-     * Unambiguous marker for JSON file specifing widget type
+     * Unambiguous marker for JSON file specifying widget type
      */
     type: WidgetTypes.Text
     /**
@@ -182,6 +182,30 @@ export interface WidgetTextMeta extends WidgetMeta {
      * Title text
      */
     descriptionTitle: string
+}
+
+/**
+ * Options configuration for widgets displaying NavigationTabs
+ */
+export interface NavigationOptions extends WidgetOptions {
+    /**
+     * Level of menu
+     */
+    navigationLevel?: number
+}
+
+/**
+ * Configuration for widgets displaying NavigationTabs
+ */
+export interface NavigationWidgetMeta extends WidgetMeta {
+    /**
+     * Unambiguous marker for JSON file specifying widget type
+     */
+    type: WidgetTypes.NavigationTabs | WidgetTypes.ViewNavigation
+    /**
+     * Options for customizing widget
+     */
+    options: NavigationOptions
 }
 
 /**

--- a/src/utils/viewTabs.ts
+++ b/src/utils/viewTabs.ts
@@ -21,7 +21,6 @@ import {
     ViewNavigationItem,
     ViewNavigationGroup,
     isViewNavigationGroup,
-    NavigationLevel,
     NavigationTab
 } from '../interfaces/navigation'
 import { breadthFirstSearch } from './breadthFirst'
@@ -37,7 +36,7 @@ const emptyArray: NavigationTab[] = []
  */
 export function getViewTabs(
     navigation: Array<Exclude<MenuItem, ViewNavigationCategory>>,
-    level: NavigationLevel,
+    level: number,
     activeView?: string
 ): NavigationTab[] {
     if (!activeView && level > 1) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -552,10 +552,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@tesler-ui/schema@0.3.4":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@tesler-ui/schema/-/schema-0.3.4.tgz#9647efa97102921bedc3296873535c56c5ba33dc"
-  integrity sha512-depDp0up1YXa03EbaEYU18oz2bvfDqtfcIHV/yAup0gX66mB0uyBs6Wu1H3RB6nykRkmWEd4m9dUg5uvpQJGcg==
+"@tesler-ui/schema@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@tesler-ui/schema/-/schema-0.4.0.tgz#7118fae41934ab154d9e3fd51aa963c95ac2430a"
+  integrity sha512-7JSGC4WPaIoXdPlkazgXBb8ZxCSwT3kJitqowL9s1qdQeZKKuhm0fczH30zzM9cHk6XU/aPO4yw4K0qUcu5rkg==
   dependencies:
     json-stable-stringify "^1.0.1"
     path "^0.12.7"


### PR DESCRIPTION
See #702

### NavigationTabsWidget
The purpose of the widget is to display navigation tabs depends on position in view's metadata. In other words this widget should be included in widgets stream.

### ViewNavigationWidget
The widget displays the same component as `NavigationTabsWidget`.
But this widget should be used in case need to exclude navigation  from widgets stream.For instance, client could decide to fix it on top of the screen.
