### PR TITLE
tsconfig erroneously treats "src" folder as part of source code base even when it's a part of "dist" folder which leads to failed repeated builds (#697)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
             "*": [
               "*",
               "generated/*",
-              "src/*",
+              "./src/*",
               "node_modules/*"
             ]
         },


### PR DESCRIPTION
See #697