### PR TITLE
`bcFetchData` should load data of hierarchy of BCs

### DIFF
--- a/src/epics/data/__tests__/bcFetchData.test.ts
+++ b/src/epics/data/__tests__/bcFetchData.test.ts
@@ -279,6 +279,37 @@ describe('bcFetchDataEpic', () => {
             expect(res.length).toBe(0)
         })
     })
+
+    it('should load data of hierarchy of BCs', () => {
+        store.getState().screen.bo.bc.bcChild = bcChild
+        store.getState().screen.bo.bc.bcChildOfChild = bcChildOfChild
+        store.getState().screen.bo.bc.lastChild = lastChild
+        store.getState().view.widgets[0] = {
+            ...getWidgetMeta(),
+            showCondition: {
+                bcName: bcChildOfChild.name,
+                isDefault: false,
+                params: {
+                    fieldKey: 'test',
+                    value: '9'
+                }
+            },
+            bcName: lastChild.name
+        }
+        const action = $do.bcFetchDataRequest({ widgetName: 'widget-example', bcName: 'bcExample' })
+        testEpic(flow(ActionsObservable.of(action), store), res => {
+            expect(res.pop()).toEqual(
+                expect.objectContaining(
+                    $do.bcFetchDataRequest({
+                        bcName: 'bcChild',
+                        widgetName: 'widget-example',
+                        ignorePageLimit: false,
+                        keepDelta: undefined
+                    })
+                )
+            )
+        })
+    })
 })
 
 /** */
@@ -320,6 +351,19 @@ const bcChild = {
     name: 'bcChild',
     parentName: 'bcExample',
     url: 'bcExample/:id/bcChild/:id'
+}
+
+const bcChildOfChild = {
+    ...bcExample,
+    name: 'bcChildOfChild',
+    parentName: 'bcChild',
+    url: 'bcExample/:id/bcChild/:id/bcChildOfChild/:id'
+}
+const lastChild = {
+    ...bcExample,
+    name: 'lastChild',
+    parentName: 'bcChildOfChild',
+    url: 'bcExample/:id/bcChild/:id/bcChildOfChild/:id/lastChild/:id'
 }
 
 const bcLazyChild = {


### PR DESCRIPTION
see #698

Consider the following example:
An action `bcFetchDataRequest` with payload `{widgetName: 'exampleWidgetName', bcName: 'grandParentBcName'}` is dispatched.
Let bcName of 'exampleWidgetName' has name 'exampleWidgetBcName'. Also 'exampleWidgetName' includes `showCondition` with `bcName: 'parentBcName'`. And hierarchy of BC names is: 'grandParentBcName' is parent of 'parentBcName', 'parentBcName' is parent of 'exampleWidgetName'. Also current `view` doesn't include other widgets with BC name 'parentBcName' or 'grandParentBcName'.

In this case `bcFetchData` epic should load data of whole hierarchy of BCs from 'grandParentBcName' to 'exampleWidgetBcName'.