### PR TITLE
URLSearchParams are ignored when comparing locations (#749)

### DIFF
--- a/src/reducers/router.ts
+++ b/src/reducers/router.ts
@@ -28,7 +28,7 @@ export function initHistory() {
     historyObj.listen((loc, action) => {
         const prevState = store.getState().router
         const nextState = parseLocation(historyObj.location)
-        const diff = shallowCompare(prevState, nextState)
+        const diff = shallowCompare(prevState, nextState, ['params'])
         if (diff.length) {
             store.dispatch($do.changeLocation({ location: nextState, action }))
         }


### PR DESCRIPTION
See #749

The reason of the problem is in search params of `location` object. See the picture below:

<img width="329" alt="Screen Shot 2022-11-18 at 02 14 29" src="https://user-images.githubusercontent.com/1095379/202594355-92ff3e50-64a8-41b9-8aba-86dc1bffcead.png">

The `params` which comes from `historyObj.location` has URLSearchParams type. Whereas the `params` from redux store is a plain object.
They wouldn't never be equal. So decided to ignore them as it already was done [here](https://github.com/tesler-platform/tesler-ui/blob/master/src/epics/router/drilldown.ts#L103).